### PR TITLE
Support Harris users migration flows

### DIFF
--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -28,6 +28,12 @@ android {
     kotlinOptions {
         moduleName = "com.amplifyframework.annotations"
     }
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {

--- a/apollo/apollo-appsync-amplify/build.gradle.kts
+++ b/apollo/apollo-appsync-amplify/build.gradle.kts
@@ -25,6 +25,12 @@ android {
     testOptions {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 apollo {
@@ -59,5 +65,5 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }

--- a/aws-analytics-pinpoint/build.gradle.kts
+++ b/aws-analytics-pinpoint/build.gradle.kts
@@ -26,6 +26,12 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.analytics.pinpoint"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -59,5 +65,5 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }

--- a/aws-api-appsync/build.gradle.kts
+++ b/aws-api-appsync/build.gradle.kts
@@ -25,6 +25,12 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.appsync"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -43,5 +49,5 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }

--- a/aws-api/build.gradle.kts
+++ b/aws-api/build.gradle.kts
@@ -29,6 +29,12 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
     testOptions {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
@@ -71,5 +77,5 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }

--- a/aws-auth-cognito/build.gradle.kts
+++ b/aws-auth-cognito/build.gradle.kts
@@ -29,6 +29,12 @@ android {
     defaultConfig {
         consumerProguardFiles += file("consumer-rules.pro")
     }
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -82,5 +88,5 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTest.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTest.kt
@@ -320,7 +320,7 @@ class AuthCanaryTest {
     fun signOut() {
         signInUser(username, password)
         val latch = CountDownLatch(1)
-        Amplify.Auth.signOut { signOutResult ->
+        Amplify.Auth.signOut("","") { signOutResult ->
             when (signOutResult) {
                 is AWSCognitoAuthSignOutResult.CompleteSignOut -> {
                     // Sign Out completed fully and without errors.
@@ -348,7 +348,7 @@ class AuthCanaryTest {
         val options = AuthSignOutOptions.builder()
             .globalSignOut(true)
             .build()
-        Amplify.Auth.signOut(options) { signOutResult ->
+        Amplify.Auth.signOut(username,"", options) { signOutResult ->
             when (signOutResult) {
                 is AWSCognitoAuthSignOutResult.CompleteSignOut -> {
                     // Sign Out completed fully and without errors.
@@ -414,7 +414,7 @@ class AuthCanaryTest {
 
     private fun signOutUser() {
         val latch = CountDownLatch(1)
-        auth.signOut { latch.countDown() }
+        auth.signOut("", "") { latch.countDown() }
         latch.await(TIMEOUT_S, TimeUnit.SECONDS)
     }
 

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTest.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTest.kt
@@ -320,7 +320,7 @@ class AuthCanaryTest {
     fun signOut() {
         signInUser(username, password)
         val latch = CountDownLatch(1)
-        Amplify.Auth.signOut("","") { signOutResult ->
+        Amplify.Auth.signOut("") { signOutResult ->
             when (signOutResult) {
                 is AWSCognitoAuthSignOutResult.CompleteSignOut -> {
                     // Sign Out completed fully and without errors.
@@ -348,7 +348,7 @@ class AuthCanaryTest {
         val options = AuthSignOutOptions.builder()
             .globalSignOut(true)
             .build()
-        Amplify.Auth.signOut(username,"", options) { signOutResult ->
+        Amplify.Auth.signOut("", options) { signOutResult ->
             when (signOutResult) {
                 is AWSCognitoAuthSignOutResult.CompleteSignOut -> {
                     // Sign Out completed fully and without errors.
@@ -414,7 +414,7 @@ class AuthCanaryTest {
 
     private fun signOutUser() {
         val latch = CountDownLatch(1)
-        auth.signOut("", "") { latch.countDown() }
+        auth.signOut("") { latch.countDown() }
         latch.await(TIMEOUT_S, TimeUnit.SECONDS)
     }
 

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTestGen2.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTestGen2.kt
@@ -330,18 +330,20 @@ class AuthCanaryTestGen2 {
     fun signOut() {
         signInUser(username, password)
         val latch = CountDownLatch(1)
-        Amplify.Auth.signOut { signOutResult ->
+        Amplify.Auth.signOut(username, "") { signOutResult ->
             when (signOutResult) {
                 is AWSCognitoAuthSignOutResult.CompleteSignOut -> {
                     // Sign Out completed fully and without errors.
                     latch.countDown()
                 }
+
                 is AWSCognitoAuthSignOutResult.PartialSignOut -> {
                     // Sign Out completed with some errors. User is signed out of the device.
                     signOutResult.hostedUIError?.let { fail("HostedUIError while signing out: $it") }
                     signOutResult.globalSignOutError?.let { fail("GlobalSignOutError while signing out: $it") }
                     signOutResult.revokeTokenError?.let { fail("RevokeTokenError: $it") }
                 }
+
                 is AWSCognitoAuthSignOutResult.FailedSignOut -> {
                     // Sign Out failed with an exception, leaving the user signed in.
                     fail("Sign out failed: ${signOutResult.exception}")
@@ -358,18 +360,20 @@ class AuthCanaryTestGen2 {
         val options = AuthSignOutOptions.builder()
             .globalSignOut(true)
             .build()
-        Amplify.Auth.signOut(options) { signOutResult ->
+        Amplify.Auth.signOut(username, "", options) { signOutResult ->
             when (signOutResult) {
                 is AWSCognitoAuthSignOutResult.CompleteSignOut -> {
                     // Sign Out completed fully and without errors.
                     latch.countDown()
                 }
+
                 is AWSCognitoAuthSignOutResult.PartialSignOut -> {
                     // Sign Out completed with some errors. User is signed out of the device.
                     signOutResult.hostedUIError?.let { fail("HostedUIError while signing out: $it") }
                     signOutResult.globalSignOutError?.let { fail("GlobalSignOutError while signing out: $it") }
                     signOutResult.revokeTokenError?.let { fail("RevokeTokenError: $it") }
                 }
+
                 is AWSCognitoAuthSignOutResult.FailedSignOut -> {
                     // Sign Out failed with an exception, leaving the user signed in.
                     fail("Sign out failed: ${signOutResult.exception}")
@@ -424,7 +428,7 @@ class AuthCanaryTestGen2 {
 
     private fun signOutUser() {
         val latch = CountDownLatch(1)
-        auth.signOut { latch.countDown() }
+        auth.signOut("", "") { latch.countDown() }
         latch.await(TIMEOUT_S, TimeUnit.SECONDS)
     }
 

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTestGen2.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/AuthCanaryTestGen2.kt
@@ -330,7 +330,7 @@ class AuthCanaryTestGen2 {
     fun signOut() {
         signInUser(username, password)
         val latch = CountDownLatch(1)
-        Amplify.Auth.signOut(username, "") { signOutResult ->
+        Amplify.Auth.signOut("") { signOutResult ->
             when (signOutResult) {
                 is AWSCognitoAuthSignOutResult.CompleteSignOut -> {
                     // Sign Out completed fully and without errors.
@@ -360,7 +360,7 @@ class AuthCanaryTestGen2 {
         val options = AuthSignOutOptions.builder()
             .globalSignOut(true)
             .build()
-        Amplify.Auth.signOut(username, "", options) { signOutResult ->
+        Amplify.Auth.signOut("", options) { signOutResult ->
             when (signOutResult) {
                 is AWSCognitoAuthSignOutResult.CompleteSignOut -> {
                     // Sign Out completed fully and without errors.
@@ -428,7 +428,7 @@ class AuthCanaryTestGen2 {
 
     private fun signOutUser() {
         val latch = CountDownLatch(1)
-        auth.signOut("", "") { latch.countDown() }
+        auth.signOut("") { latch.countDown() }
         latch.await(TIMEOUT_S, TimeUnit.SECONDS)
     }
 

--- a/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/CredentialStoreStateMachineForAuthInstrumentationTest.kt
+++ b/aws-auth-cognito/src/androidTest/java/com/amplifyframework/auth/cognito/CredentialStoreStateMachineForAuthInstrumentationTest.kt
@@ -28,7 +28,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class CredentialStoreStateMachineInstrumentationTest {
+class CredentialStoreStateMachineForAuthInstrumentationTest {
     private val context = InstrumentationRegistry.getInstrumentation().context
 
     private val configuration = AuthConfigurationProvider.getAuthConfigurationObject()

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -301,12 +301,11 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     }
 
     override fun fetchAuthSession(
-        username: String,
         userId: String,
         onSuccess: Consumer<AuthSession>,
         onError: Consumer<AuthException>
     ) =
-        enqueue(onSuccess, onError) { queueFacade.fetchAuthSession(username, userId) }
+        enqueue(onSuccess, onError) { queueFacade.fetchAuthSession(userId) }
 
     override fun fetchAuthSession(
         options: AuthFetchSessionOptions,
@@ -421,22 +420,21 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
         enqueue(onSuccess, onError) { queueFacade.getCurrentUser() }
 
     override fun signOut(
-        username: String,
-        userId: String, onComplete: Consumer<AuthSignOutResult>
+        userId: String,
+        onComplete: Consumer<AuthSignOutResult>
     ) = enqueue(
         onComplete,
         onError = ::throwIt
-    ) { queueFacade.signOut(username, userId) }
+    ) { queueFacade.signOut(userId) }
 
     override fun signOut(
-        username: String,
         userId: String,
         options: AuthSignOutOptions,
         onComplete: Consumer<AuthSignOutResult>
     ) = enqueue(
         onComplete,
         onError = ::throwIt
-    ) { queueFacade.signOut(username, userId, options) }
+    ) { queueFacade.signOut(userId, options) }
 
     override fun deleteUser(onSuccess: Action, onError: Consumer<AuthException>) = enqueue(onSuccess, onError) {
         queueFacade.deleteUser()
@@ -549,8 +547,8 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
      * @param onSuccess Success callback
      * @param onError Error callback
      */
-    fun clearFederationToIdentityPool(username:String, userId: String, onSuccess: Action, onError: Consumer<AuthException>) =
-        enqueue(onSuccess, onError) { queueFacade.clearFederationToIdentityPool(username,userId) }
+    fun clearFederationToIdentityPool(userId: String, onSuccess: Action, onError: Consumer<AuthException>) =
+        enqueue(onSuccess, onError) { queueFacade.clearFederationToIdentityPool(userId) }
 
     fun fetchMFAPreference(onSuccess: Consumer<UserMFAPreference>, onError: Consumer<AuthException>) =
         enqueue(onSuccess, onError) { queueFacade.fetchMFAPreference() }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -130,10 +130,22 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
         realPlugin.initialize()
     }
 
+    override fun configure(pluginConfiguration: JSONObject, userId: String?, context: Context) {
+        try {
+            configure(AuthConfiguration.fromJson(pluginConfiguration), userId, context)
+        } catch (exception: Exception) {
+            throw ConfigurationException(
+                "Failed to configure AWSCognitoAuthPlugin.",
+                "Make sure your amplifyconfiguration.json is valid.",
+                exception
+            )
+        }
+    }
+
     @Throws(AmplifyException::class)
     override fun configure(pluginConfiguration: JSONObject, context: Context) {
         try {
-            configure(AuthConfiguration.fromJson(pluginConfiguration), context)
+            configure(AuthConfiguration.fromJson(pluginConfiguration), null, context)
         } catch (exception: Exception) {
             throw ConfigurationException(
                 "Failed to configure AWSCognitoAuthPlugin.",
@@ -146,7 +158,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     @InternalAmplifyApi
     override fun configure(amplifyOutputs: AmplifyOutputsData, context: Context) {
         try {
-            configure(AuthConfiguration.from(amplifyOutputs), context)
+            configure(AuthConfiguration.from(amplifyOutputs), null, context)
         } catch (exception: Exception) {
             throw ConfigurationException(
                 "Failed to configure AWSCognitoAuthPlugin.",
@@ -156,7 +168,7 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
         }
     }
 
-    private fun configure(configuration: AuthConfiguration, context: Context) {
+    private fun configure(configuration: AuthConfiguration, userId: String?, context: Context) {
         val credentialStoreClient = CredentialStoreClient(configuration, context, logger)
         val authEnvironment = AuthEnvironment(
             context,
@@ -173,7 +185,8 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
             configuration,
             authEnvironment,
             authStateMachine,
-            logger
+            logger,
+            userId
         )
 
         useCaseFactory = AuthUseCaseFactory(realPlugin, authEnvironment, authStateMachine)
@@ -288,6 +301,14 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     }
 
     override fun fetchAuthSession(
+        username: String,
+        userId: String,
+        onSuccess: Consumer<AuthSession>,
+        onError: Consumer<AuthException>
+    ) =
+        enqueue(onSuccess, onError) { queueFacade.fetchAuthSession(username, userId) }
+
+    override fun fetchAuthSession(
         options: AuthFetchSessionOptions,
         onSuccess: Consumer<AuthSession>,
         onError: Consumer<AuthException>
@@ -399,15 +420,23 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     override fun getCurrentUser(onSuccess: Consumer<AuthUser>, onError: Consumer<AuthException>) =
         enqueue(onSuccess, onError) { queueFacade.getCurrentUser() }
 
-    override fun signOut(onComplete: Consumer<AuthSignOutResult>) = enqueue(
+    override fun signOut(
+        username: String,
+        userId: String, onComplete: Consumer<AuthSignOutResult>
+    ) = enqueue(
         onComplete,
         onError = ::throwIt
-    ) { queueFacade.signOut() }
+    ) { queueFacade.signOut(username, userId) }
 
-    override fun signOut(options: AuthSignOutOptions, onComplete: Consumer<AuthSignOutResult>) = enqueue(
+    override fun signOut(
+        username: String,
+        userId: String,
+        options: AuthSignOutOptions,
+        onComplete: Consumer<AuthSignOutResult>
+    ) = enqueue(
         onComplete,
         onError = ::throwIt
-    ) { queueFacade.signOut(options) }
+    ) { queueFacade.signOut(username, userId, options) }
 
     override fun deleteUser(onSuccess: Action, onError: Consumer<AuthException>) = enqueue(onSuccess, onError) {
         queueFacade.deleteUser()
@@ -520,8 +549,8 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
      * @param onSuccess Success callback
      * @param onError Error callback
      */
-    fun clearFederationToIdentityPool(onSuccess: Action, onError: Consumer<AuthException>) =
-        enqueue(onSuccess, onError) { queueFacade.clearFederationToIdentityPool() }
+    fun clearFederationToIdentityPool(username:String, userId: String, onSuccess: Action, onError: Consumer<AuthException>) =
+        enqueue(onSuccess, onError) { queueFacade.clearFederationToIdentityPool(username,userId) }
 
     fun fetchMFAPreference(onSuccess: Consumer<UserMFAPreference>, onError: Consumer<AuthException>) =
         enqueue(onSuccess, onError) { queueFacade.fetchMFAPreference() }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -427,6 +427,11 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
         onError = ::throwIt
     ) { queueFacade.signOut(userId) }
 
+    override fun signOut(onComplete: Consumer<AuthSignOutResult>) = enqueue(
+    onComplete,
+    onError = ::throwIt)
+    { queueFacade.signOut() }
+
     override fun signOut(
         userId: String,
         options: AuthSignOutOptions,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -308,6 +308,13 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
         enqueue(onSuccess, onError) { queueFacade.fetchAuthSession(userId) }
 
     override fun fetchAuthSession(
+        userId: String,
+        options: AuthFetchSessionOptions,
+        onSuccess: Consumer<AuthSession>,
+        onError: Consumer<AuthException>
+    ) = enqueue(onSuccess, onError) { queueFacade.fetchAuthSession(userId, options) }
+
+    override fun fetchAuthSession(
         options: AuthFetchSessionOptions,
         onSuccess: Consumer<AuthSession>,
         onError: Consumer<AuthException>

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthStateMachine.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AuthStateMachine.kt
@@ -33,8 +33,7 @@ import com.amplifyframework.auth.cognito.actions.SignUpCognitoActions
 import com.amplifyframework.auth.cognito.actions.UserAuthSignInCognitoActions
 import com.amplifyframework.auth.cognito.actions.WebAuthnSignInCognitoActions
 import com.amplifyframework.auth.exceptions.InvalidStateException
-import com.amplifyframework.statemachine.Environment
-import com.amplifyframework.statemachine.StateMachine
+import com.amplifyframework.statemachine.StateMachineForAuth
 import com.amplifyframework.statemachine.StateMachineResolver
 import com.amplifyframework.statemachine.codegen.states.AuthState
 import com.amplifyframework.statemachine.codegen.states.AuthenticationState
@@ -56,10 +55,11 @@ import com.amplifyframework.statemachine.codegen.states.WebAuthnSignInState
 
 internal class AuthStateMachine(
     resolver: StateMachineResolver<AuthState>,
-    environment: Environment,
+    environment: AuthEnvironment,
     initialState: AuthState? = null
-) : StateMachine<AuthState, Environment>(resolver, environment, initialState = initialState) {
-    constructor(environment: Environment, initialState: AuthState? = null) : this(
+) : StateMachineForAuth(resolver, environment, initialState = initialState) {
+
+    constructor(environment: AuthEnvironment, initialState: AuthState? = null) : this(
         AuthState.Resolver(
             AuthenticationState.Resolver(
                 SignInState.Resolver(
@@ -94,7 +94,7 @@ internal class AuthStateMachine(
     )
 
     companion object {
-        fun logging(environment: Environment) = AuthStateMachine(
+        fun logging(environment: AuthEnvironment) = AuthStateMachine(
             AuthState.Resolver(
                 AuthenticationState.Resolver(
                     SignInState.Resolver(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
@@ -240,10 +240,9 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
         delegate.handleWebUISignInResponse(intent)
     }
 
-    suspend fun fetchAuthSession(username: String, userId: String): AuthSession {
+    suspend fun fetchAuthSession(userId: String): AuthSession {
         return suspendCoroutine { continuation ->
             delegate.fetchAuthSession(
-                username,
                 userId,
                 { continuation.resume(it) },
                 { continuation.resumeWithException(it) }
@@ -487,15 +486,15 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
         }
     }
 
-    suspend fun signOut(username: String, userId: String): AuthSignOutResult {
+    suspend fun signOut(userId: String): AuthSignOutResult {
         return suspendCoroutine { continuation ->
-            delegate.signOut(username, userId) { continuation.resume(it) }
+            delegate.signOut(userId) { continuation.resume(it) }
         }
     }
 
-    suspend fun signOut(username: String, userId: String, options: AuthSignOutOptions): AuthSignOutResult {
+    suspend fun signOut(userId: String, options: AuthSignOutOptions): AuthSignOutResult {
         return suspendCoroutine { continuation ->
-            delegate.signOut(username, userId, options) { continuation.resume(it) }
+            delegate.signOut(userId, options) { continuation.resume(it) }
         }
     }
 
@@ -524,10 +523,9 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
         }
     }
 
-    suspend fun clearFederationToIdentityPool(username: String, userId: String) {
+    suspend fun clearFederationToIdentityPool(userId: String) {
         return suspendCoroutine { continuation ->
             delegate.clearFederationToIdentityPool(
-                username,
                 userId,
                 { continuation.resume(Unit) },
                 { continuation.resumeWithException(it) }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
@@ -240,6 +240,16 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
         delegate.handleWebUISignInResponse(intent)
     }
 
+    suspend fun fetchAuthSession(username: String, userId: String): AuthSession {
+        return suspendCoroutine { continuation ->
+            delegate.fetchAuthSession(
+                username,
+                userId,
+                { continuation.resume(it) },
+                { continuation.resumeWithException(it) }
+            )
+        }
+    }
     suspend fun fetchAuthSession(): AuthSession {
         return suspendCoroutine { continuation ->
             delegate.fetchAuthSession(
@@ -477,15 +487,15 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
         }
     }
 
-    suspend fun signOut(): AuthSignOutResult {
+    suspend fun signOut(username: String, userId: String): AuthSignOutResult {
         return suspendCoroutine { continuation ->
-            delegate.signOut { continuation.resume(it) }
+            delegate.signOut(username, userId) { continuation.resume(it) }
         }
     }
 
-    suspend fun signOut(options: AuthSignOutOptions): AuthSignOutResult {
+    suspend fun signOut(username: String, userId: String, options: AuthSignOutOptions): AuthSignOutResult {
         return suspendCoroutine { continuation ->
-            delegate.signOut(options) { continuation.resume(it) }
+            delegate.signOut(username, userId, options) { continuation.resume(it) }
         }
     }
 
@@ -514,9 +524,11 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
         }
     }
 
-    suspend fun clearFederationToIdentityPool() {
+    suspend fun clearFederationToIdentityPool(username: String, userId: String) {
         return suspendCoroutine { continuation ->
             delegate.clearFederationToIdentityPool(
+                username,
+                userId,
                 { continuation.resume(Unit) },
                 { continuation.resumeWithException(it) }
             )

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
@@ -269,6 +269,17 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
         }
     }
 
+    suspend fun fetchAuthSession(userId: String, options: AuthFetchSessionOptions): AuthSession {
+        return suspendCoroutine { continuation ->
+            delegate.fetchAuthSession(
+                userId,
+                options,
+                { continuation.resume(it) },
+                { continuation.resumeWithException(it) }
+            )
+        }
+    }
+
     suspend fun rememberDevice() {
         return suspendCoroutine { continuation ->
             delegate.rememberDevice(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/KotlinAuthFacadeInternal.kt
@@ -249,6 +249,7 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
             )
         }
     }
+
     suspend fun fetchAuthSession(): AuthSession {
         return suspendCoroutine { continuation ->
             delegate.fetchAuthSession(
@@ -492,6 +493,16 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
         }
     }
 
+    suspend fun signOut(): AuthSignOutResult {
+        return suspendCoroutine { continuation ->
+            delegate.signOut(
+                userId = "",
+                signOutAllUsers = true,
+                options = AuthSignOutOptions.builder().build()
+            ) { continuation.resume(it) }
+        }
+    }
+
     suspend fun signOut(userId: String, options: AuthSignOutOptions): AuthSignOutResult {
         return suspendCoroutine { continuation ->
             delegate.signOut(userId, options) { continuation.resume(it) }
@@ -541,6 +552,7 @@ internal class KotlinAuthFacadeInternal(private val delegate: RealAWSCognitoAuth
             )
         }
     }
+
     suspend fun verifyTOTPSetup(code: String, options: AuthVerifyTOTPSetupOptions) {
         return suspendCoroutine { continuation ->
             delegate.verifyTOTPSetup(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -1590,6 +1590,78 @@ internal class RealAWSCognitoAuthPlugin(
         }
     }
 
+    fun fetchAuthSession(
+        userId: String,
+        options: AuthFetchSessionOptions,
+        onSuccess: Consumer<AuthSession>,
+        onError: Consumer<AuthException>
+    ) {
+        val forceRefresh = options.forceRefresh
+        authStateMachine.getCurrentState(userId) { authState ->
+            when (val authZState = authState.authZState) {
+                is AuthorizationState.Configured -> {
+                    authStateMachine.send(
+                        AuthorizationEvent(AuthorizationEvent.EventType.FetchUnAuthSession(userId)),
+                        userId
+                    )
+                    _fetchAuthSession(userId, onSuccess)
+                }
+
+                is AuthorizationState.SessionEstablished -> {
+                    val credential = authZState.amplifyCredential
+                    if (!credential.isValid() || forceRefresh) {
+                        if (credential is AmplifyCredential.IdentityPoolFederated) {
+                            authStateMachine.send(
+                                AuthorizationEvent(
+                                    AuthorizationEvent.EventType.StartFederationToIdentityPool(
+                                        credential.federatedToken,
+                                        credential.identityId,
+                                        credential
+                                    )
+                                ), userId
+                            )
+                        } else {
+                            authStateMachine.send(
+                                AuthorizationEvent(AuthorizationEvent.EventType.RefreshSession(userId, credential)),
+                                userId
+                            )
+                        }
+                        _fetchAuthSession(userId, onSuccess)
+                    } else {
+                        onSuccess.accept(credential.getCognitoSession())
+                    }
+                }
+
+                is AuthorizationState.Error -> {
+                    val error = authZState.exception
+                    if (error is SessionError) {
+                        val amplifyCredential = error.amplifyCredential
+                        if (amplifyCredential is AmplifyCredential.IdentityPoolFederated) {
+                            authStateMachine.send(
+                                AuthorizationEvent(
+                                    AuthorizationEvent.EventType.StartFederationToIdentityPool(
+                                        amplifyCredential.federatedToken,
+                                        amplifyCredential.identityId,
+                                        amplifyCredential
+                                    )
+                                ), userId
+                            )
+                        } else {
+//                            authStateMachine.send(
+//                                AuthorizationEvent(AuthorizationEvent.EventType.RefreshSession(amplifyCredential))
+//                            )
+                        }
+                        _fetchAuthSession(userId, onSuccess)
+                    } else {
+                        onError.accept(InvalidStateException())
+                    }
+                }
+
+                else -> onError.accept(InvalidStateException())
+            }
+        }
+    }
+
     private fun _fetchAuthSession(userId: String?, onSuccess: Consumer<AuthSession>) {
         val token = StateChangeListenerToken()
         authStateMachine.listen(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPlugin.kt
@@ -588,7 +588,7 @@ internal class RealAWSCognitoAuthPlugin(
                 // Continue sign in
                 is AuthenticationState.SignedOut,
                 is AuthenticationState.Configured
-                -> {
+                    -> {
                     _signIn(username, password, signInOptions, onSuccess, onError)
                 }
 
@@ -603,6 +603,7 @@ internal class RealAWSCognitoAuthPlugin(
                                     authStateMachine.cancel(token)
                                     _signIn(username, password, signInOptions, onSuccess, onError)
                                 }
+
                                 else -> Unit
                             }
                         },
@@ -1475,7 +1476,8 @@ internal class RealAWSCognitoAuthPlugin(
                             )
                         } else {
                             authStateMachine.send(
-                                AuthorizationEvent(AuthorizationEvent.EventType.RefreshSession(userId, credential)), userId
+                                AuthorizationEvent(AuthorizationEvent.EventType.RefreshSession(userId, credential)),
+                                userId
                             )
                         }
                         _fetchAuthSession(userId, onSuccess)
@@ -1500,7 +1502,12 @@ internal class RealAWSCognitoAuthPlugin(
                             )
                         } else {
                             authStateMachine.send(
-                                AuthorizationEvent(AuthorizationEvent.EventType.RefreshSession(userId, amplifyCredential)),
+                                AuthorizationEvent(
+                                    AuthorizationEvent.EventType.RefreshSession(
+                                        userId,
+                                        amplifyCredential
+                                    )
+                                ),
                                 userId
                             )
                         }
@@ -1626,12 +1633,16 @@ internal class RealAWSCognitoAuthPlugin(
 
                             is ConfigurationException -> {
                                 val errorResult = InvalidAccountTypeException(error)
-                                onSuccess.accept(AmplifyCredential.Empty(userId.orEmpty()).getCognitoSession(errorResult))
+                                onSuccess.accept(
+                                    AmplifyCredential.Empty(userId.orEmpty()).getCognitoSession(errorResult)
+                                )
                             }
 
                             else -> {
                                 val errorResult = UnknownException("Fetch auth session failed.", error)
-                                onSuccess.accept(AmplifyCredential.Empty(userId.orEmpty()).getCognitoSession(errorResult))
+                                onSuccess.accept(
+                                    AmplifyCredential.Empty(userId.orEmpty()).getCognitoSession(errorResult)
+                                )
                             }
                         }
                     }
@@ -2247,12 +2258,13 @@ internal class RealAWSCognitoAuthPlugin(
     }
 
     fun signOut(userId: String, onComplete: Consumer<AuthSignOutResult>) {
-        signOut(userId, AuthSignOutOptions.builder().build(), onComplete)
+        signOut(userId, AuthSignOutOptions.builder().build(), false, onComplete)
     }
 
     fun signOut(
         userId: String,
         options: AuthSignOutOptions,
+        signOutAllUsers: Boolean = false,
         onComplete: Consumer<AuthSignOutResult>
     ) {
         authStateMachine.getCurrentState(userId) { authState ->
@@ -2266,9 +2278,10 @@ internal class RealAWSCognitoAuthPlugin(
                     val event = AuthenticationEvent(
                         AuthenticationEvent.EventType.SignOutRequested(
                             SignOutData(
-                                userId,
-                                options.isGlobalSignOut,
-                                (options as? AWSCognitoAuthSignOutOptions)?.browserPackage
+                                userId = userId,
+                                globalSignOut = options.isGlobalSignOut,
+                                browserPackage = (options as? AWSCognitoAuthSignOutOptions)?.browserPackage,
+                                signOutAllUsers = signOutAllUsers
                             )
                         )
                     )
@@ -2587,7 +2600,8 @@ internal class RealAWSCognitoAuthPlugin(
                                         authZState.exception is SessionError &&
                                         authZState.exception.amplifyCredential is AmplifyCredential.IdentityPoolFederated
                                 ) -> {
-                    val event = AuthenticationEvent(AuthenticationEvent.EventType.ClearFederationToIdentityPool(userId = userId))
+                    val event =
+                        AuthenticationEvent(AuthenticationEvent.EventType.ClearFederationToIdentityPool(userId = userId))
                     authStateMachine.send(event)
                     _clearFederationToIdentityPool(onSuccess, onError)
                 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthCognitoActions.kt
@@ -28,7 +28,7 @@ internal object AuthCognitoActions : AuthActions {
     override fun initializeAuthConfigurationAction(event: AuthEvent.EventType.ConfigureAuth) =
         Action<AuthEnvironment>("InitAuthConfig") { id, dispatcher ->
             logger.verbose("$id Starting execution")
-            val storedCredentials = credentialStoreClient.loadCredentials(CredentialType.Amplify)
+            val storedCredentials = credentialStoreClient.loadCredentials(CredentialType.Amplify(event.userId))
             val evt = configuration.userPool?.run {
                 AuthEvent(AuthEvent.EventType.ConfigureAuthentication(configuration, storedCredentials))
             } ?: AuthEvent(AuthEvent.EventType.ConfigureAuthorization(configuration, storedCredentials))
@@ -51,7 +51,7 @@ internal object AuthCognitoActions : AuthActions {
             logger.verbose("$id Starting execution")
             val handleEvent = { credentials: AmplifyCredential ->
                 when (credentials) {
-                    AmplifyCredential.Empty -> AuthorizationEvent(AuthorizationEvent.EventType.Configure)
+                    is AmplifyCredential.Empty -> AuthorizationEvent(AuthorizationEvent.EventType.Configure)
                     else -> AuthorizationEvent(AuthorizationEvent.EventType.CachedCredentialsAvailable(credentials))
                 }
             }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthenticationCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthenticationCognitoActions.kt
@@ -30,7 +30,6 @@ import com.amplifyframework.statemachine.codegen.events.AuthEvent
 import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
 import com.amplifyframework.statemachine.codegen.events.SignInEvent
 import com.amplifyframework.statemachine.codegen.events.SignOutEvent
-import kotlinx.serialization.StringFormat
 
 internal object AuthenticationCognitoActions : AuthenticationActions {
     override fun configureAuthenticationAction(event: AuthenticationEvent.EventType.Configure) =
@@ -50,9 +49,11 @@ internal object AuthenticationCognitoActions : AuthenticationActions {
                         )
                     )
                 }
+
                 is AmplifyCredential.IdentityPoolFederated -> {
                     AuthenticationEvent(AuthenticationEvent.EventType.InitializedFederated)
                 }
+
                 else -> AuthenticationEvent(AuthenticationEvent.EventType.InitializedSignedOut(SignedOutData()))
             }
             logger.verbose("$id Sending event ${evt.type}")
@@ -88,6 +89,7 @@ internal object AuthenticationCognitoActions : AuthenticationActions {
                         )
                     }
                 }
+
                 is SignInData.CustomAuthSignInData -> {
                     if (data.username != null) {
                         SignInEvent(
@@ -101,6 +103,7 @@ internal object AuthenticationCognitoActions : AuthenticationActions {
                         )
                     }
                 }
+
                 is SignInData.CustomSRPAuthSignInData -> {
                     if (data.username != null && data.password != null) {
                         SignInEvent(
@@ -118,9 +121,11 @@ internal object AuthenticationCognitoActions : AuthenticationActions {
                         )
                     }
                 }
+
                 is SignInData.HostedUISignInData -> {
                     SignInEvent(SignInEvent.EventType.InitiateHostedUISignIn(data))
                 }
+
                 is SignInData.MigrationAuthSignInData -> {
                     if (data.username != null && data.password != null) {
                         SignInEvent(
@@ -139,6 +144,7 @@ internal object AuthenticationCognitoActions : AuthenticationActions {
                         )
                     }
                 }
+
                 is SignInData.UserAuthSignInData -> {
                     if (data.username != null) {
                         SignInEvent(
@@ -170,7 +176,8 @@ internal object AuthenticationCognitoActions : AuthenticationActions {
     override fun initiateSignOutAction(
         userId: String,
         event: AuthenticationEvent.EventType.SignOutRequested,
-        signedInData: SignedInData?
+        signedInData: SignedInData?,
+        signOutAllUsers: Boolean
     ) = Action<AuthEnvironment>("InitSignOut") { id, dispatcher ->
         logger.verbose("$id Starting execution")
 
@@ -178,9 +185,10 @@ internal object AuthenticationCognitoActions : AuthenticationActions {
             signedInData != null && signedInData.signInMethod is SignInMethod.HostedUI -> {
                 SignOutEvent(SignOutEvent.EventType.InvokeHostedUISignOut(userId, event.signOutData, signedInData))
             }
+
             signedInData != null &&
-                signedInData.signInMethod == SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.UNKNOWN) &&
-                hostedUIClient != null -> {
+                    signedInData.signInMethod == SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.UNKNOWN) &&
+                    hostedUIClient != null -> {
                 /*
                 If sign in method is unknown, this is due to SignInMethod not being tracked in Amplify v1. We try to
                 assume that hosted ui sign in may have been used if hostedUIClient is configured. This only happens if
@@ -188,13 +196,22 @@ internal object AuthenticationCognitoActions : AuthenticationActions {
                  */
                 SignOutEvent(SignOutEvent.EventType.InvokeHostedUISignOut(userId, event.signOutData, signedInData))
             }
+
             signedInData != null && event.signOutData.globalSignOut -> {
                 SignOutEvent(SignOutEvent.EventType.SignOutGlobally(userId, signedInData))
             }
+
             signedInData != null && !event.signOutData.globalSignOut -> {
                 SignOutEvent(SignOutEvent.EventType.RevokeToken(userId, signedInData))
             }
-            else -> SignOutEvent(SignOutEvent.EventType.SignOutLocally(userId, signedInData))
+
+            else -> SignOutEvent(
+                SignOutEvent.EventType.SignOutLocally(
+                    userId = userId,
+                    signedInData = signedInData,
+                    signOutAllUsers = signOutAllUsers
+                )
+            )
         }
         logger.verbose("$id Sending event ${evt.type}")
         dispatcher.send(evt)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthorizationCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthorizationCognitoActions.kt
@@ -102,7 +102,7 @@ internal object AuthorizationCognitoActions : AuthorizationActions {
                 }
             }
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, signedInData.email.orEmpty())
+            dispatcher.send(evt, signedInData.userId)
         }
 
     override fun initiateRefreshSessionAction(userId: String, amplifyCredential: AmplifyCredential) =
@@ -134,11 +134,7 @@ internal object AuthorizationCognitoActions : AuthorizationActions {
                 )
             }
             logger.verbose("$id Sending event ${evt.type}")
-            val username = when (amplifyCredential) {
-                is AmplifyCredential.UserPoolTypeCredential -> amplifyCredential.signedInData.email.orEmpty()
-                else -> ""
-            }
-            dispatcher.send(evt, username)
+            dispatcher.send(evt, userId)
         }
 
     override fun initializeFederationToIdentityPool(
@@ -164,7 +160,7 @@ internal object AuthorizationCognitoActions : AuthorizationActions {
             val evt =
                 DeleteUserEvent(DeleteUserEvent.EventType.DeleteUser(event.accessToken, event.userId, event.username))
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, event.username)
+            dispatcher.send(evt, event.userId)
         }
 
     override fun persistCredentials(amplifyCredential: AmplifyCredential) =
@@ -180,10 +176,10 @@ internal object AuthorizationCognitoActions : AuthorizationActions {
                 AuthEvent(AuthEvent.EventType.CachedCredentialsFailed)
             }
             logger.verbose("$id Sending event ${evt.type}")
-            val username = when (amplifyCredential) {
-                is AmplifyCredential.UserPoolTypeCredential -> amplifyCredential.signedInData.email.orEmpty()
+            val userId = when (amplifyCredential) {
+                is AmplifyCredential.UserPoolTypeCredential -> amplifyCredential.signedInData.userId
                 else -> ""
             }
-            dispatcher.send(evt, username)
+            dispatcher.send(evt, userId)
         }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthorizationCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/AuthorizationCognitoActions.kt
@@ -102,7 +102,7 @@ internal object AuthorizationCognitoActions : AuthorizationActions {
                 }
             }
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, signedInData.userId)
+            dispatcher.send(evt, signedInData.userId, true)
         }
 
     override fun initiateRefreshSessionAction(userId: String, amplifyCredential: AmplifyCredential) =

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/CredentialStoreCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/CredentialStoreCognitoActions.kt
@@ -16,6 +16,7 @@
 package com.amplifyframework.auth.cognito.actions
 
 import com.amplifyframework.auth.cognito.CredentialStoreEnvironment
+import com.amplifyframework.auth.cognito.getCognitoSession
 import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.actions.CredentialStoreActions
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
@@ -30,7 +31,7 @@ internal object CredentialStoreCognitoActions : CredentialStoreActions {
             logger.verbose("$id Starting execution")
             val evt = try {
                 val credentials = legacyCredentialStore.retrieveCredential()
-                if (credentials != AmplifyCredential.Empty) {
+                if (credentials !is AmplifyCredential.Empty) {
                     // migrate credentials
                     credentialStore.saveCredential(credentials)
                     legacyCredentialStore.deleteCredential()
@@ -53,7 +54,7 @@ internal object CredentialStoreCognitoActions : CredentialStoreActions {
                     legacyCredentialStore.deleteASFDevice()
                 }
 
-                CredentialStoreEvent(CredentialStoreEvent.EventType.LoadCredentialStore(CredentialType.Amplify))
+                CredentialStoreEvent(CredentialStoreEvent.EventType.LoadCredentialStore(CredentialType.Amplify(credentials.getCognitoSession().userSubResult.value)))
             } catch (error: CredentialStoreError) {
                 CredentialStoreEvent(CredentialStoreEvent.EventType.ThrowError(error))
             }
@@ -66,11 +67,15 @@ internal object CredentialStoreCognitoActions : CredentialStoreActions {
             logger.verbose("$id Starting execution")
             val evt = try {
                 when (credentialType) {
-                    CredentialType.Amplify -> credentialStore.deleteCredential()
+                    is CredentialType.Amplify -> credentialStore.deleteCredential(userId = credentialType.userId)
                     is CredentialType.Device -> credentialStore.deleteDeviceKeyCredential(credentialType.username)
                     CredentialType.ASF -> credentialStore.deleteASFDevice()
                 }
-                CredentialStoreEvent(CredentialStoreEvent.EventType.CompletedOperation(AmplifyCredential.Empty))
+                if (credentialType is CredentialType.Amplify) {
+                    CredentialStoreEvent(CredentialStoreEvent.EventType.CompletedOperation(AmplifyCredential.Empty(credentialType.userId.orEmpty())))
+                } else{
+                    CredentialStoreEvent(CredentialStoreEvent.EventType.CompletedOperation(AmplifyCredential.Empty(null)))
+                }
             } catch (error: CredentialStoreError) {
                 CredentialStoreEvent(CredentialStoreEvent.EventType.ThrowError(error))
             }
@@ -83,7 +88,7 @@ internal object CredentialStoreCognitoActions : CredentialStoreActions {
             logger.verbose("$id Starting execution")
             val evt = try {
                 val credentials: AmplifyCredential = when (credentialType) {
-                    CredentialType.Amplify -> credentialStore.retrieveCredential()
+                    is CredentialType.Amplify -> credentialStore.retrieveCredential(credentialType.userId)
                     is CredentialType.Device -> {
                         AmplifyCredential.DeviceData(credentialStore.retrieveDeviceMetadata(credentialType.username))
                     }
@@ -102,7 +107,7 @@ internal object CredentialStoreCognitoActions : CredentialStoreActions {
             logger.verbose("$id Starting execution")
             val evt = try {
                 when (credentialType) {
-                    CredentialType.Amplify -> credentialStore.saveCredential(credentials)
+                    is CredentialType.Amplify -> credentialStore.saveCredential(credentials)
                     is CredentialType.Device -> {
                         val deviceData = credentials as? AmplifyCredential.DeviceMetaDataTypeCredential
                         deviceData?.let {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/DeviceSRPCognitoSignInActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/DeviceSRPCognitoSignInActions.kt
@@ -44,6 +44,7 @@ internal object DeviceSRPCognitoSignInActions : DeviceSRPSignInActions {
     private const val KEY_SECRET_HASH = "SECRET_HASH"
     private const val KEY_SRP_B = "SRP_B"
     private const val KEY_USERNAME = "USERNAME"
+    private const val USER_EMAIL = "USER_EMAIL"
     private const val KEY_DEVICE_KEY = "DEVICE_KEY"
     private const val KEY_DEVICE_GROUP_KEY = "DEVICE_GROUP_KEY"
 
@@ -166,6 +167,7 @@ internal object DeviceSRPCognitoSignInActions : DeviceSRPSignInActions {
                     DeviceSRPSignInEvent(DeviceSRPSignInEvent.EventType.FinalizeSignIn())
                     SignInChallengeHelper.evaluateNextStep(
                         username = username,
+                        email = event.metadata[USER_EMAIL].orEmpty(),
                         signInMethod = SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_SRP_AUTH),
                         authenticationResult = respondToAuthChallenge.authenticationResult,
                         challengeNameType = respondToAuthChallenge.challengeName,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/FetchAuthSessionCognitoActions.kt
@@ -104,7 +104,7 @@ internal object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
                 AuthorizationEvent(AuthorizationEvent.EventType.ThrowError(signedInData.userId, e))
             }
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, signedInData.email.orEmpty())
+            dispatcher.send(evt, signedInData.userId)
         }
 
     override fun refreshAuthSessionAction(logins: LoginsMapProvider) =
@@ -188,10 +188,10 @@ internal object FetchAuthSessionCognitoActions : FetchAuthSessionActions {
             logger.verbose("$id Starting execution")
             val evt = AuthorizationEvent(AuthorizationEvent.EventType.Refreshed(amplifyCredential))
             logger.verbose("$id Sending event ${evt.type}")
-            val username = when (amplifyCredential) {
-                is AmplifyCredential.UserPoolTypeCredential -> amplifyCredential.signedInData.email.orEmpty()
+            val userId = when (amplifyCredential) {
+                is AmplifyCredential.UserPoolTypeCredential -> amplifyCredential.signedInData.userId
                 else -> ""
             }
-            dispatcher.send(evt, username)
+            dispatcher.send(evt, userId)
         }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/HostedUICognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/HostedUICognitoActions.kt
@@ -48,7 +48,7 @@ internal object HostedUICognitoActions : HostedUIActions {
     override fun fetchHostedUISignInToken(event: HostedUIEvent.EventType.FetchToken, browserPackage: String?) =
         Action<AuthEnvironment>("InitHostedUITokenFetch") { id, dispatcher ->
             logger.verbose("$id Starting execution")
-            var email: String? = null
+            var userid: String? = null
             val evt = try {
                 // This should never happen, but if it does it is due to bad Oauth configuration block in
                 // amplify json config
@@ -57,8 +57,7 @@ internal object HostedUICognitoActions : HostedUIActions {
                 val token = hostedUIClient.fetchToken(event.uri)
                 val userId = token.accessToken?.let { JWTParser.getClaim(it, "sub") } ?: ""
                 val username = token.accessToken?.let { JWTParser.getClaim(it, "username") } ?: ""
-                email = username
-
+                userid = userId
                 val signedInData = SignedInData(
                     userId,
                     username,
@@ -69,7 +68,7 @@ internal object HostedUICognitoActions : HostedUIActions {
                 )
                 val tokenFetchedEvent = HostedUIEvent(HostedUIEvent.EventType.TokenFetched)
                 logger.verbose("$id Sending event ${tokenFetchedEvent.type}")
-                dispatcher.send(tokenFetchedEvent, username, ignoreUsername = true)
+                dispatcher.send(tokenFetchedEvent, userId, ignoreUsername = true)
 
                 AuthenticationEvent(AuthenticationEvent.EventType.SignInCompleted(signedInData, DeviceMetadata.Empty))
             } catch (e: Exception) {
@@ -80,6 +79,6 @@ internal object HostedUICognitoActions : HostedUIActions {
                 AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
             }
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, email.orEmpty())
+            dispatcher.send(evt, userid.orEmpty())
         }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/HostedUICognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/HostedUICognitoActions.kt
@@ -48,6 +48,7 @@ internal object HostedUICognitoActions : HostedUIActions {
     override fun fetchHostedUISignInToken(event: HostedUIEvent.EventType.FetchToken, browserPackage: String?) =
         Action<AuthEnvironment>("InitHostedUITokenFetch") { id, dispatcher ->
             logger.verbose("$id Starting execution")
+            var email: String? = null
             val evt = try {
                 // This should never happen, but if it does it is due to bad Oauth configuration block in
                 // amplify json config
@@ -56,17 +57,19 @@ internal object HostedUICognitoActions : HostedUIActions {
                 val token = hostedUIClient.fetchToken(event.uri)
                 val userId = token.accessToken?.let { JWTParser.getClaim(it, "sub") } ?: ""
                 val username = token.accessToken?.let { JWTParser.getClaim(it, "username") } ?: ""
+                email = username
 
                 val signedInData = SignedInData(
                     userId,
                     username,
                     Date(),
                     SignInMethod.HostedUI(browserPackage),
-                    token
+                    token,
+                    username
                 )
                 val tokenFetchedEvent = HostedUIEvent(HostedUIEvent.EventType.TokenFetched)
                 logger.verbose("$id Sending event ${tokenFetchedEvent.type}")
-                dispatcher.send(tokenFetchedEvent)
+                dispatcher.send(tokenFetchedEvent, username, ignoreUsername = true)
 
                 AuthenticationEvent(AuthenticationEvent.EventType.SignInCompleted(signedInData, DeviceMetadata.Empty))
             } catch (e: Exception) {
@@ -77,6 +80,6 @@ internal object HostedUICognitoActions : HostedUIActions {
                 AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
             }
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt)
+            dispatcher.send(evt, email.orEmpty())
         }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/HostedUICognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/HostedUICognitoActions.kt
@@ -68,7 +68,7 @@ internal object HostedUICognitoActions : HostedUIActions {
                 )
                 val tokenFetchedEvent = HostedUIEvent(HostedUIEvent.EventType.TokenFetched)
                 logger.verbose("$id Sending event ${tokenFetchedEvent.type}")
-                dispatcher.send(tokenFetchedEvent, userId, ignoreUsername = true)
+                dispatcher.send(tokenFetchedEvent, userId, ignoreUserId = true)
 
                 AuthenticationEvent(AuthenticationEvent.EventType.SignInCompleted(signedInData, DeviceMetadata.Empty))
             } catch (e: Exception) {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/MigrateAuthCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/MigrateAuthCognitoActions.kt
@@ -34,6 +34,7 @@ import com.amplifyframework.statemachine.codegen.events.SignInEvent
 
 internal object MigrateAuthCognitoActions : MigrateAuthActions {
     private const val KEY_USERNAME = "USERNAME"
+    private const val USER_EMAIL = "USER_EMAIL"
     private const val KEY_PASSWORD = "PASSWORD"
     private const val KEY_SECRET_HASH = "SECRET_HASH"
     private const val KEY_USERID_FOR_SRP = "USER_ID_FOR_SRP"
@@ -72,11 +73,12 @@ internal object MigrateAuthCognitoActions : MigrateAuthActions {
                     response?.let {
                         SignInChallengeHelper.evaluateNextStep(
                             username = event.username,
+                            email = event.metadata[USER_EMAIL].orEmpty(),
                             challengeNameType = response.challengeName,
                             session = response.session,
                             challengeParameters = response.challengeParameters,
                             authenticationResult = response.authenticationResult,
-                            signInMethod = SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_AUTH)
+                            signInMethod = SignInMethod.ApiBased(SignInMethod.ApiBased.AuthType.USER_AUTH),
                         )
                     } ?: throw ServiceException("Sign in failed", AmplifyException.TODO_RECOVERY_SUGGESTION)
                 } else {
@@ -107,6 +109,7 @@ internal object MigrateAuthCognitoActions : MigrateAuthActions {
                         }
                         SignInChallengeHelper.evaluateNextStep(
                             username = username,
+                            email = event.metadata[USER_EMAIL].orEmpty(),
                             challengeNameType = response.challengeName,
                             session = response.session,
                             challengeParameters = response.challengeParameters,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SRPCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SRPCognitoActions.kt
@@ -49,6 +49,7 @@ internal object SRPCognitoActions : SRPActions {
     private const val KEY_USER_ID_FOR_SRP = "USER_ID_FOR_SRP"
     private const val KEY_SECRET_HASH = "SECRET_HASH"
     private const val KEY_USERNAME = "USERNAME"
+    private const val USER_EMAIL = "USER_EMAIL"
     private const val KEY_USERID_FOR_SRP = "USER_ID_FOR_SRP"
     private const val KEY_DEVICE_KEY = "DEVICE_KEY"
     private const val KEY_CHALLENGE_NAME = "CHALLENGE_NAME"
@@ -291,6 +292,7 @@ internal object SRPCognitoActions : SRPActions {
                 if (response != null) {
                     SignInChallengeHelper.evaluateNextStep(
                         username = username,
+                        email = metadata[USER_EMAIL].orEmpty(),
                         challengeNameType = response.challengeName,
                         session = response.session,
                         challengeParameters = response.challengeParameters,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SetupTOTPCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SetupTOTPCognitoActions.kt
@@ -156,6 +156,7 @@ internal object SetupTOTPCognitoActions : SetupTOTPActions {
                 response?.let {
                     SignInChallengeHelper.evaluateNextStep(
                         username = eventType.username,
+                        email = eventType.username,
                         challengeNameType = response.challengeName,
                         session = response.session,
                         challengeParameters = response.challengeParameters,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInChallengeCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInChallengeCognitoActions.kt
@@ -37,6 +37,7 @@ import com.amplifyframework.statemachine.codegen.events.SignInChallengeEvent
 internal object SignInChallengeCognitoActions : SignInChallengeActions {
     private const val KEY_SECRET_HASH = "SECRET_HASH"
     private const val KEY_USERNAME = "USERNAME"
+    private const val USER_EMAIL = "USER_EMAIL"
     private const val KEY_PREFIX_USER_ATTRIBUTE = "userAttributes."
     override fun verifyChallengeAuthAction(
         answer: String,
@@ -54,6 +55,7 @@ internal object SignInChallengeCognitoActions : SignInChallengeActions {
             if (isMfaSetupSelectionChallenge(challenge)) {
                 val event = SignInChallengeHelper.evaluateNextStep(
                     username = username ?: "",
+                    email = metadata[USER_EMAIL].orEmpty(),
                     challengeNameType = ChallengeNameType.MfaSetup,
                     session = challenge.session,
                     challengeParameters = mapOf("MFAS_CAN_SETUP" to answer),
@@ -102,6 +104,7 @@ internal object SignInChallengeCognitoActions : SignInChallengeActions {
             response?.let {
                 SignInChallengeHelper.evaluateNextStep(
                     username = username ?: "",
+                    metadata[USER_EMAIL].orEmpty(),
                     challengeNameType = response.challengeName,
                     session = response.session,
                     challengeParameters = response.challengeParameters,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCognitoActions.kt
@@ -60,7 +60,7 @@ internal object SignInCognitoActions : SignInActions {
                 )
             )
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, event.username)
+            dispatcher.send(evt)
         }
 
     override fun startCustomAuthAction(event: SignInEvent.EventType.InitiateSignInWithCustom) =
@@ -70,7 +70,7 @@ internal object SignInCognitoActions : SignInActions {
                 CustomSignInEvent.EventType.InitiateCustomSignIn(event.username, event.metadata)
             )
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, event.username)
+            dispatcher.send(evt)
         }
 
     override fun startMigrationAuthAction(event: SignInEvent.EventType.InitiateMigrateAuth) =
@@ -85,7 +85,7 @@ internal object SignInCognitoActions : SignInActions {
                 )
             )
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, event.username)
+            dispatcher.send(evt)
         }
 
     override fun startCustomAuthWithSRPAction(event: SignInEvent.EventType.InitiateCustomSignInWithSRP): Action =
@@ -93,7 +93,7 @@ internal object SignInCognitoActions : SignInActions {
             logger.verbose("$id Starting execution")
             val evt = SRPEvent(SRPEvent.EventType.InitiateSRPWithCustom(event.username, event.password, event.metadata))
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, event.username)
+            dispatcher.send(evt)
         }
 
     override fun startDeviceSRPAuthAction(event: SignInEvent.EventType.InitiateSignInWithDeviceSRP) =
@@ -103,7 +103,7 @@ internal object SignInCognitoActions : SignInActions {
                 DeviceSRPSignInEvent.EventType.RespondDeviceSRPChallenge(event.username, event.metadata)
             )
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, event.username)
+            dispatcher.send(evt)
         }
 
     override fun initResolveChallenge(event: SignInEvent.EventType.ReceivedChallenge) =
@@ -153,7 +153,7 @@ internal object SignInCognitoActions : SignInActions {
                 SignInEvent(SignInEvent.EventType.ThrowError(e))
             }
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, event.signedInData.email.orEmpty())
+            dispatcher.send(evt, event.signedInData.userId)
         }
 
     override fun startHostedUIAuthAction(event: SignInEvent.EventType.InitiateHostedUISignIn) =
@@ -191,7 +191,7 @@ internal object SignInCognitoActions : SignInActions {
                 WebAuthnEvent(WebAuthnEvent.EventType.AssertCredentialOptions(signInContext))
             }
             logger.verbose("$id sending event ${evt.type}")
-            dispatcher.send(evt, signInContext.username)
+            dispatcher.send(evt)
         }
 
     override fun autoSignInAction(event: SignInEvent.EventType.InitiateAutoSignIn): Action =
@@ -242,11 +242,11 @@ internal object SignInCognitoActions : SignInActions {
             } catch (e: Exception) {
                 val signInError = SignInEvent(SignInEvent.EventType.ThrowError(e))
                 logger.verbose("$id Sending event ${signInError.type}")
-                dispatcher.send(signInError, event.signInData.username)
+                dispatcher.send(signInError, event.signInData.userId.orEmpty())
 
                 AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn())
             }
             logger.verbose("$id Sending event ${evt.type}")
-            dispatcher.send(evt, event.signInData.username)
+            dispatcher.send(evt, event.signInData.userId.orEmpty())
         }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/SignInCustomCognitoActions.kt
@@ -32,6 +32,7 @@ import com.amplifyframework.statemachine.codegen.events.SignInEvent
 internal object SignInCustomCognitoActions : CustomSignInActions {
     private const val KEY_SECRET_HASH = "SECRET_HASH"
     private const val KEY_USERNAME = "USERNAME"
+    private const val USER_EMAIL = "USER_EMAIL"
     private const val KEY_DEVICE_KEY = "DEVICE_KEY"
     private const val KEY_USERID_FOR_SRP = "USER_ID_FOR_SRP"
     override fun initiateCustomSignInAuthAction(event: CustomSignInEvent.EventType.InitiateCustomSignIn): Action =
@@ -73,6 +74,7 @@ internal object SignInCustomCognitoActions : CustomSignInActions {
                     )
                     SignInChallengeHelper.evaluateNextStep(
                         username = activeUserName,
+                        email = event.metadata[USER_EMAIL].orEmpty(),
                         challengeNameType = initiateAuthResponse.challengeName,
                         session = initiateAuthResponse.session,
                         challengeParameters = initiateAuthResponse.challengeParameters,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/UserAuthSignInCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/UserAuthSignInCognitoActions.kt
@@ -35,6 +35,7 @@ internal object UserAuthSignInCognitoActions : UserAuthSignInActions {
     private const val KEY_DEVICE_KEY = "DEVICE_KEY"
     private const val KEY_USERID_FOR_SRP = "USER_ID_FOR_SRP"
     private const val KEY_PREFERRED_CHALLENGE = "PREFERRED_CHALLENGE"
+    private const val USER_EMAIL = "USER_EMAIL"
 
     override fun initiateUserAuthSignIn(event: SignInEvent.EventType.InitiateUserAuth): Action =
         Action<AuthEnvironment>("InitUserAuth") { id, dispatcher ->
@@ -84,6 +85,7 @@ internal object UserAuthSignInCognitoActions : UserAuthSignInActions {
 
                     SignInChallengeHelper.evaluateNextStep(
                         username = activeUserName,
+                        email = event.metadata[USER_EMAIL].orEmpty(),
                         challengeNameType = ChallengeNameType.SelectChallenge,
                         session = resolvedSession,
                         availableChallenges = listOfChallenges,
@@ -105,6 +107,7 @@ internal object UserAuthSignInCognitoActions : UserAuthSignInActions {
 
                     SignInChallengeHelper.evaluateNextStep(
                         username = activeUserName,
+                        email = event.metadata[USER_EMAIL].orEmpty(),
                         challengeNameType = initiateAuthResponse.challengeName,
                         session = resolvedSession,
                         challengeParameters = initiateAuthResponse.challengeParameters,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/WebAuthnSignInCognitoActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/actions/WebAuthnSignInCognitoActions.kt
@@ -58,6 +58,7 @@ internal object WebAuthnSignInCognitoActions : WebAuthnSignInActions {
 
             SignInChallengeHelper.evaluateNextStep(
                 username = signInContext.username,
+                email = signInContext.username,
                 challengeNameType = response.challengeName,
                 session = response.session,
                 challengeParameters = response.challengeParameters,
@@ -99,6 +100,7 @@ internal object WebAuthnSignInCognitoActions : WebAuthnSignInActions {
 
             SignInChallengeHelper.evaluateNextStep(
                 username = signInContext.username,
+                email = signInContext.username,
                 challengeNameType = ChallengeNameType.WebAuthn,
                 session = signInContext.session,
                 challengeParameters = response.challengeParameters,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStore.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStore.kt
@@ -65,9 +65,12 @@ internal class AWSCognitoAuthCredentialStore(
 
     //region Retrieve Credentials
     override fun retrieveCredential(userId: String?): AmplifyCredential {
-        return userId?.let {
-            deserializeCredential(userId, keyValue.get(generateKeyWithPrefix(it + "_", Key_Session)))
-        } ?: deserializeCredential(null, keyValue.get(generateKey(Key_Session)))
+        if (userId == null) {
+            return deserializeCredential(null, keyValue.get(generateKey(Key_Session)))
+        }
+        return deserializeCredential(userId, keyValue.get(generateKeyWithPrefix(userId + "_", Key_Session)))
+            .takeIf { it !is AmplifyCredential.Empty }
+            ?: deserializeCredential(null, keyValue.get(generateKey(Key_Session)))
     }
 
     override fun retrieveDeviceMetadata(username: String): DeviceMetadata = deserializeMetadata(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStore.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoAuthCredentialStore.kt
@@ -36,6 +36,7 @@ internal class AWSCognitoAuthCredentialStore(
         private const val Key_Session = "session"
         private const val Key_DeviceMetadata = "deviceMetadata"
         private const val Key_ASFDevice = "asfDevice"
+        private const val SESSION_KEY_REGEX = "^[a-fA-F0-9-]+_amplify.*\\.session$"
     }
 
     private var keyValue: KeyValueRepository =
@@ -43,9 +44,19 @@ internal class AWSCognitoAuthCredentialStore(
 
     //region Save Credentials
     override fun saveCredential(credential: AmplifyCredential) {
+        if (credential is AmplifyCredential.Empty && credential.clearAllSessions) {
+            // Remove all logged in users sessions.
+            keyValue.removeAll(SESSION_KEY_REGEX)
+            return
+        }
         val userId =
-            if (credential is AmplifyCredential.UserPool) credential.signedInData.userId else if (credential is AmplifyCredential.IdentityPool) credential.identityId else null
+            when (credential) {
+                is AmplifyCredential.UserPool -> credential.signedInData.userId
+                is AmplifyCredential.IdentityPool -> credential.identityId
+                else -> null
+            }
         val sessionKey = userId?.let { generateKeyWithPrefix(it + "_", Key_Session) }
+
         keyValue.put(
             sessionKey ?: generateKey(Key_Session),
             serializeCredential(credential)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStore.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/data/AWSCognitoLegacyCredentialStore.kt
@@ -101,7 +101,7 @@ internal class AWSCognitoLegacyCredentialStore(
     }
 
     @Synchronized
-    override fun retrieveCredential(): AmplifyCredential {
+    override fun retrieveCredential(userId: String?): AmplifyCredential {
         val signedInData = retrieveSignedInData()
         val awsCredentials = retrieveAWSCredentials()
         val identityId = retrieveIdentityId()
@@ -113,6 +113,7 @@ internal class AWSCognitoLegacyCredentialStore(
                     signedInData != null -> {
                         AmplifyCredential.UserAndIdentityPool(signedInData, identityId, awsCredentials)
                     }
+
                     federateToIdentityPoolToken != null -> {
                         AmplifyCredential.IdentityPoolFederated(
                             federateToIdentityPoolToken,
@@ -120,11 +121,18 @@ internal class AWSCognitoLegacyCredentialStore(
                             awsCredentials
                         )
                     }
-                    else -> { AmplifyCredential.IdentityPool(identityId, awsCredentials) }
+
+                    else -> {
+                        AmplifyCredential.IdentityPool(identityId, awsCredentials)
+                    }
                 }
             }
-            signedInData != null -> { AmplifyCredential.UserPool(signedInData) }
-            else -> AmplifyCredential.Empty
+
+            signedInData != null -> {
+                AmplifyCredential.UserPool(signedInData)
+            }
+
+            else -> AmplifyCredential.Empty(userId.orEmpty())
         }
     }
 
@@ -135,7 +143,7 @@ internal class AWSCognitoLegacyCredentialStore(
         return AmplifyCredential.ASFDevice(deviceId)
     }
 
-    override fun deleteCredential() {
+    override fun deleteCredential(userId: String?) {
         deleteAWSCredentials()
         deleteIdentityId()
         deleteCognitoUserPoolTokens()
@@ -225,7 +233,8 @@ internal class AWSCognitoLegacyCredentialStore(
             tokenUsername,
             Date(0),
             signInMethod,
-            cognitoUserPoolTokens
+            cognitoUserPoolTokens,
+            "legacy"
         )
     }
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/EventDispatcher.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/EventDispatcher.kt
@@ -17,5 +17,5 @@ package com.amplifyframework.statemachine
 
 internal interface EventDispatcher {
     fun send(event: StateMachineEvent) {}
-    fun send(event: StateMachineEvent, username: String, ignoreUsername: Boolean = false) {}
+    fun send(event: StateMachineEvent, userId: String, ignoreUsername: Boolean = false) {}
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/EventDispatcher.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/EventDispatcher.kt
@@ -17,5 +17,5 @@ package com.amplifyframework.statemachine
 
 internal interface EventDispatcher {
     fun send(event: StateMachineEvent) {}
-    fun send(event: StateMachineEvent, userId: String, ignoreUsername: Boolean = false) {}
+    fun send(event: StateMachineEvent, userId: String, ignoreUserId: Boolean = false) {}
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/EventDispatcher.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/EventDispatcher.kt
@@ -16,5 +16,6 @@
 package com.amplifyframework.statemachine
 
 internal interface EventDispatcher {
-    fun send(event: StateMachineEvent)
+    fun send(event: StateMachineEvent) {}
+    fun send(event: StateMachineEvent, username: String, ignoreUsername: Boolean = false) {}
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/StateMachineForAuth.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/StateMachineForAuth.kt
@@ -45,8 +45,8 @@ internal open class StateMachineForAuth(
     private val _state = MutableStateFlow(initialState ?: resolver.defaultState)
     val state = _state.asStateFlow()
 
-    private fun getAuthStateForUser(userId: String?, ignoreUsername: Boolean = false): AuthState {
-        if (userId.isNullOrEmpty() || ignoreUsername) {
+    private fun getAuthStateForUser(userId: String?, ignoreUserId: Boolean = false): AuthState {
+        if (userId.isNullOrEmpty() || ignoreUserId) {
             return _state.value
         }
         return authStateRepo.get(userId) ?: authStateRepo.getDefaultConfiguredState()
@@ -181,9 +181,9 @@ internal open class StateMachineForAuth(
         }
     }
 
-    override fun send(event: StateMachineEvent, userId: String, ignoreUsername: Boolean) {
+    override fun send(event: StateMachineEvent, userId: String, ignoreUserId: Boolean) {
         stateMachineScope.launch {
-            process(userId, event, ignoreUsername)
+            process(userId, event, ignoreUserId)
         }
     }
 
@@ -210,8 +210,8 @@ internal open class StateMachineForAuth(
      * the state machine will execute any effects from the event resolution process.
      * @param event event to apply on current state for resolution
      */
-    private fun process(userId: String, event: StateMachineEvent, ignoreUsername: Boolean = false) {
-        val currentState = getAuthStateForUser(userId, ignoreUsername)
+    private fun process(userId: String, event: StateMachineEvent, ignoreUserId: Boolean = false) {
+        val currentState = getAuthStateForUser(userId, ignoreUserId)
         val resolution = resolver.resolve(currentState, event)
         if (currentState != resolution.newState) {
             setAuthState(userId, resolution.newState)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/AuthenticationActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/AuthenticationActions.kt
@@ -23,6 +23,7 @@ internal interface AuthenticationActions {
     fun configureAuthenticationAction(event: AuthenticationEvent.EventType.Configure): Action
     fun initiateSignInAction(event: AuthenticationEvent.EventType.SignInRequested): Action
     fun initiateSignOutAction(
+        userId: String,
         event: AuthenticationEvent.EventType.SignOutRequested,
         signedInData: SignedInData?
     ): Action

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/AuthenticationActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/AuthenticationActions.kt
@@ -25,6 +25,7 @@ internal interface AuthenticationActions {
     fun initiateSignOutAction(
         userId: String,
         event: AuthenticationEvent.EventType.SignOutRequested,
-        signedInData: SignedInData?
+        signedInData: SignedInData?,
+        signOutAllUsers: Boolean
     ): Action
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/AuthorizationActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/AuthorizationActions.kt
@@ -23,9 +23,9 @@ import com.amplifyframework.statemachine.codegen.events.DeleteUserEvent
 
 internal interface AuthorizationActions {
     fun configureAuthorizationAction(): Action
-    fun initializeFetchUnAuthSession(): Action
+    fun initializeFetchUnAuthSession(userId: String): Action
     fun initializeFetchAuthSession(signedInData: SignedInData): Action
-    fun initiateRefreshSessionAction(amplifyCredential: AmplifyCredential): Action
+    fun initiateRefreshSessionAction(userId: String, amplifyCredential: AmplifyCredential): Action
     fun initializeFederationToIdentityPool(federatedToken: FederatedToken, developerProvidedIdentityId: String?): Action
     fun initiateDeleteUser(event: DeleteUserEvent.EventType.DeleteUser): Action
     fun persistCredentials(amplifyCredential: AmplifyCredential): Action

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/DeleteUserActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/DeleteUserActions.kt
@@ -18,6 +18,6 @@ package com.amplifyframework.statemachine.codegen.actions
 import com.amplifyframework.statemachine.Action
 
 internal interface DeleteUserActions {
-    fun initDeleteUserAction(accessToken: String): Action
-    fun initiateSignOut(): Action
+    fun initDeleteUserAction(accessToken: String, userId: String): Action
+    fun initiateSignOut(userId: String): Action
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/SignOutActions.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/actions/SignOutActions.kt
@@ -19,9 +19,9 @@ import com.amplifyframework.statemachine.Action
 import com.amplifyframework.statemachine.codegen.events.SignOutEvent
 
 internal interface SignOutActions {
-    fun hostedUISignOutAction(event: SignOutEvent.EventType.InvokeHostedUISignOut): Action
+    fun hostedUISignOutAction(userId: String, event: SignOutEvent.EventType.InvokeHostedUISignOut): Action
     fun localSignOutAction(event: SignOutEvent.EventType.SignOutLocally): Action
-    fun globalSignOutAction(event: SignOutEvent.EventType.SignOutGlobally): Action
+    fun globalSignOutAction(userId: String, event: SignOutEvent.EventType.SignOutGlobally): Action
     fun revokeTokenAction(event: SignOutEvent.EventType.RevokeToken): Action
     fun buildRevokeTokenErrorAction(event: SignOutEvent.EventType.SignOutGloballyError): Action
     fun userCancelledAction(event: SignOutEvent.EventType.UserCancelled): Action

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AmplifyCredential.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AmplifyCredential.kt
@@ -36,7 +36,7 @@ internal sealed class AmplifyCredential {
 
     @Serializable
     @SerialName("empty")
-    object Empty : AmplifyCredential()
+    data class Empty(val userId: String?) : AmplifyCredential()
 
     @Serializable
     @SerialName("userPool")
@@ -82,9 +82,9 @@ internal sealed class AmplifyCredential {
 internal data class FederatedToken(val token: String, val providerName: String) {
     override fun toString(): String {
         return "FederatedToken(" +
-            "token = ${token.substring(0..4)}***, " +
-            "providerName = $providerName" +
-            ")"
+                "token = ${token.substring(0..4)}***, " +
+                "providerName = $providerName" +
+                ")"
     }
 }
 
@@ -104,10 +104,10 @@ internal data class CognitoUserPoolTokens(
 ) {
     override fun toString(): String {
         return "CognitoUserPoolTokens(" +
-            "idToken = ${idToken?.substring(0..4)}***, " +
-            "accessToken = ${accessToken?.substring(0..4)}***, " +
-            "refreshToken = ${refreshToken?.substring(0..4)}***" +
-            ")"
+                "idToken = ${idToken?.substring(0..4)}***, " +
+                "accessToken = ${accessToken?.substring(0..4)}***, " +
+                "refreshToken = ${refreshToken?.substring(0..4)}***" +
+                ")"
     }
 
     override fun equals(other: Any?): Boolean {
@@ -141,16 +141,16 @@ internal data class AWSCredentials(
 
     override fun toString(): String {
         return "AWSCredentials(" +
-            "accessKeyId = ${accessKeyId?.substring(0..4)}***, " +
-            "secretAccessKey = ${secretAccessKey?.substring(0..4)}***, " +
-            "sessionToken = ${sessionToken?.substring(0..4)}***, " +
-            "expiration = $expiration" +
-            ")"
+                "accessKeyId = ${accessKeyId?.substring(0..4)}***, " +
+                "secretAccessKey = ${secretAccessKey?.substring(0..4)}***, " +
+                "sessionToken = ${sessionToken?.substring(0..4)}***, " +
+                "expiration = $expiration" +
+                ")"
     }
 }
 
 internal sealed class CredentialType {
-    object Amplify : CredentialType()
+    data class Amplify(val userId: String?) : CredentialType()
     data class Device(val username: String) : CredentialType()
     object ASF : CredentialType()
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AmplifyCredential.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AmplifyCredential.kt
@@ -36,7 +36,7 @@ internal sealed class AmplifyCredential {
 
     @Serializable
     @SerialName("empty")
-    data class Empty(val userId: String?) : AmplifyCredential()
+    data class Empty(val userId: String?, val clearAllSessions: Boolean = false) : AmplifyCredential()
 
     @Serializable
     @SerialName("userPool")

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AuthCredentialStore.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AuthCredentialStore.kt
@@ -18,8 +18,8 @@ package com.amplifyframework.statemachine.codegen.data
 internal interface AuthCredentialStore {
     // Amplify Credentials
     fun saveCredential(credential: AmplifyCredential)
-    fun retrieveCredential(): AmplifyCredential
-    fun deleteCredential()
+    fun retrieveCredential(userId: String? = null): AmplifyCredential
+    fun deleteCredential(userId: String? = null)
 
     // Device Metadata
     fun saveDeviceMetadata(username: String, deviceMetadata: DeviceMetadata)

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AuthStateRepo.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/AuthStateRepo.kt
@@ -1,0 +1,159 @@
+package com.amplifyframework.statemachine.codegen.data
+
+import android.content.Context
+import com.amplifyframework.core.store.EncryptedKeyValueRepository
+import com.amplifyframework.statemachine.codegen.states.AuthState
+import com.amplifyframework.statemachine.codegen.states.AuthenticationState
+import com.amplifyframework.statemachine.codegen.states.AuthorizationState
+import com.amplifyframework.statemachine.codegen.states.SignUpState
+import com.amplifyframework.statemachine.util.LifoMap
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Repository for managing authentication states.
+ * This class uses an in-memory LIFO map and an encrypted key-value store to persist authentication states.
+ *
+ * @constructor Creates an instance of AuthStateRepo with the provided context.
+ * @param context The context used to initialize the encrypted key-value store.
+ */
+internal class AuthStateRepo private constructor(context: Context) {
+
+    // In-memory LIFO map to store authentication states.
+    private val authStateMap = LifoMap.empty<String, AuthState>()
+
+    // Encrypted key-value store for persisting authentication states.
+    private val encryptedStore = EncryptedKeyValueRepository(
+        context,
+        PREF_KEY
+    )
+
+    /**
+     * Stores the given authentication state associated with the specified key.
+     *
+     * @param key The key to associate with the authentication state.
+     * @param value The authentication state to store.
+     */
+    fun put(key: String, value: AuthState) {
+        if (value.isSignedOut) {
+            remove(key)
+            return
+        }
+        if (value.isSessionEstablished) {
+            encryptedStore.put(
+                key,
+                serializeAuthNAndZState(
+                    AuthNAndAuthZ(
+                        value.authNState as AuthenticationState.SignedIn,
+                        value.authZState as AuthorizationState.SessionEstablished
+                    )
+                )
+            )
+            // Remove all states from the in-memory map.
+            // This enables us to login again with different credentials.
+            authStateMap.clear()
+            return
+        }
+        authStateMap.push(key, value)
+    }
+
+    /**
+     * Retrieves the authentication state associated with the specified key.
+     *
+     * @param key The key associated with the authentication state.
+     * @return The authentication state if found, or null otherwise.
+     */
+    fun get(key: String): AuthState? {
+        return if (authStateMap.containsKey(key)) {
+            authStateMap.get(key)
+        } else {
+            deserializeAuthNAndZState(encryptedStore.get(key))?.let {
+                AuthState.Configured(it.authNState, it.authZState, null)
+            }
+        }
+    }
+
+    /**
+     * Removes the authentication state associated with the specified key.
+     *
+     * @param key The key associated with the authentication state to remove.
+     */
+    fun remove(key: String) {
+        authStateMap.pop(key)
+        encryptedStore.remove(key)
+    }
+
+    /**
+     * Retrieves the most recently added authentication state.
+     *
+     * @return The most recently added authentication state, or null if none exists.
+     */
+    fun activeState(): AuthState? {
+        return authStateMap.peek()
+    }
+
+    /**
+     * Retrieves the key associated with the most recently added authentication state.
+     *
+     * @return The key associated with the most recently added authentication state, or null if none exists.
+     */
+    fun activeStateKey(): String? {
+        return authStateMap.peekKey()
+    }
+
+    fun getDefaultConfiguredState(): AuthState {
+        return AuthState.Configured(
+            authNState = AuthenticationState.SignedOut(SignedOutData()),
+            authZState = AuthorizationState.Configured(),
+            authSignUpState = SignUpState.NotStarted()
+        )
+    }
+
+    private fun serializeAuthNAndZState(authState: AuthNAndAuthZ): String {
+        return Json.encodeToString(authState)
+    }
+
+    private fun deserializeAuthNAndZState(encodedState: String?): AuthNAndAuthZ? {
+        return runCatching {
+            encodedState?.let { Json.decodeFromString(it) as AuthNAndAuthZ }
+        }.getOrNull()
+    }
+
+    companion object {
+
+        // Preference key for the encrypted key-value store.
+        private val PREF_KEY = Companion::class.java.name
+
+        private var instance: AuthStateRepo? = null
+
+        /**
+         * Retrieves the singleton instance of AuthStateRepo.
+         *
+         * @param context The context used to initialize the encrypted key-value store.
+         * @return The singleton instance of AuthStateRepo.
+         */
+        @Synchronized
+        fun getInstance(context: Context): AuthStateRepo {
+            if (instance == null) {
+                instance = AuthStateRepo(context)
+            }
+            return instance!!
+        }
+    }
+}
+
+@Serializable
+private data class AuthNAndAuthZ(
+    val authNState: AuthenticationState.SignedIn,
+    val authZState: AuthorizationState.SessionEstablished
+)
+
+internal val AuthState.isSessionEstablished: Boolean
+    get() = this is AuthState.Configured &&
+            this.authNState is AuthenticationState.SignedIn &&
+            this.authZState is AuthorizationState.SessionEstablished
+
+private val AuthState.isSignedOut: Boolean
+    get() = this is AuthState.Configured &&
+            this.authNState is AuthenticationState.SignedOut

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignOutData.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignOutData.kt
@@ -16,6 +16,7 @@
 package com.amplifyframework.statemachine.codegen.data
 
 internal data class SignOutData(
+    val userId: String,
     val globalSignOut: Boolean = false,
     val browserPackage: String? = null,
     val bypassCancel: Boolean = false // When user deleted, even if sign out is cancelled, proceed to sign out locally

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignOutData.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignOutData.kt
@@ -19,5 +19,6 @@ internal data class SignOutData(
     val userId: String,
     val globalSignOut: Boolean = false,
     val browserPackage: String? = null,
-    val bypassCancel: Boolean = false // When user deleted, even if sign out is cancelled, proceed to sign out locally
+    val bypassCancel: Boolean = false, // When user deleted, even if sign out is cancelled, proceed to sign out locally
+    val signOutAllUsers: Boolean = false, // If true, sign out all users in the app
 )

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignedInData.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/data/SignedInData.kt
@@ -26,7 +26,8 @@ internal data class SignedInData(
     @Serializable(DateSerializer::class)
     val signedInDate: Date,
     val signInMethod: SignInMethod,
-    val cognitoUserPoolTokens: CognitoUserPoolTokens
+    val cognitoUserPoolTokens: CognitoUserPoolTokens,
+    val email: String? = null
 ) {
     override fun equals(other: Any?): Boolean {
         return if (super.equals(other)) {
@@ -35,8 +36,8 @@ internal data class SignedInData(
             false
         } else {
             userId == other.userId && username == other.username &&
-                signInMethod == other.signInMethod &&
-                cognitoUserPoolTokens == other.cognitoUserPoolTokens
+                    signInMethod == other.signInMethod &&
+                    cognitoUserPoolTokens == other.cognitoUserPoolTokens && email == other.email
         }
     }
 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/AuthEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/AuthEvent.kt
@@ -23,7 +23,7 @@ import java.util.Date
 internal class AuthEvent(val eventType: EventType, override val time: Date? = null) :
     StateMachineEvent {
     sealed class EventType {
-        data class ConfigureAuth(val configuration: AuthConfiguration) : EventType()
+        data class ConfigureAuth(val configuration: AuthConfiguration, val userId: String?) : EventType()
         data class ReceivedCachedCredentials(val storedCredentials: AmplifyCredential) : EventType()
         object CachedCredentialsFailed : EventType()
         data class ConfigureAuthentication(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/AuthenticationEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/AuthenticationEvent.kt
@@ -42,7 +42,7 @@ internal class AuthenticationEvent(val eventType: EventType, override val time: 
         data class SignOutRequested(val signOutData: SignOutData) : EventType()
         data class CancelSignIn(val error: Exception? = null) : EventType()
         data class CancelSignOut(val signedInData: SignedInData, val deviceMetadata: DeviceMetadata) : EventType()
-        data class ClearFederationToIdentityPool(val id: String = "") : EventType()
+        data class ClearFederationToIdentityPool(val id: String = "", val userId: String) : EventType()
         data class ThrowError(val exception: Exception) : EventType()
     }
 

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/AuthorizationEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/AuthorizationEvent.kt
@@ -26,13 +26,13 @@ internal class AuthorizationEvent(val eventType: EventType, override val time: D
     sealed class EventType {
         object Configure : EventType()
         object FetchAuthSession : EventType()
-        object FetchUnAuthSession : EventType()
+        data class FetchUnAuthSession(val userId: String?) : EventType()
         data class Fetched(val identityId: String, val awsCredentials: AWSCredentials) : EventType()
-        data class RefreshSession(val amplifyCredential: AmplifyCredential) : EventType()
+        data class RefreshSession(val userId: String, val amplifyCredential: AmplifyCredential) : EventType()
         data class Refreshed(val amplifyCredential: AmplifyCredential) : EventType()
         data class CachedCredentialsAvailable(val amplifyCredential: AmplifyCredential) : EventType()
         data class UserDeleted(val id: String = "") : EventType()
-        data class ThrowError(val exception: Exception) : EventType()
+        data class ThrowError(val userId: String?, val exception: Exception) : EventType()
         data class StartFederationToIdentityPool(
             val token: FederatedToken,
             val identityId: String?,

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/DeleteUserEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/DeleteUserEvent.kt
@@ -23,9 +23,9 @@ internal class DeleteUserEvent(
     override val time: Date? = null,
 ) : StateMachineEvent {
     sealed class EventType {
-        data class DeleteUser(val accessToken: String) : EventType()
-        data class UserDeleted(val id: String = "") : EventType()
-        data class ThrowError(val exception: Exception, val signOutUser: Boolean) : EventType()
+        data class DeleteUser(val accessToken: String, val userId: String = "", val username: String = "") : EventType()
+        data class UserDeleted(val id: String = "", val userId: String) : EventType()
+        data class ThrowError(val exception: Exception, val userId: String, val signOutUser: Boolean) : EventType()
     }
 
     override val type: String = eventType.javaClass.simpleName

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignOutEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignOutEvent.kt
@@ -29,9 +29,10 @@ internal class SignOutEvent(
     override val time: Date? = null,
 ) : StateMachineEvent {
     sealed class EventType {
-        data class InvokeHostedUISignOut(val signOutData: SignOutData, val signedInData: SignedInData) : EventType()
+        data class InvokeHostedUISignOut(val userId: String, val signOutData: SignOutData, val signedInData: SignedInData) : EventType()
 
         data class SignOutLocally(
+            val userId: String,
             val signedInData: SignedInData?,
             val hostedUIErrorData: HostedUIErrorData? = null,
             val globalSignOutErrorData: GlobalSignOutErrorData? = null,
@@ -39,17 +40,20 @@ internal class SignOutEvent(
         ) : EventType()
 
         data class SignOutGlobally(
+            val userId: String,
             val signedInData: SignedInData,
             val hostedUIErrorData: HostedUIErrorData? = null
         ) : EventType()
 
         data class RevokeToken(
+            val userId: String,
             val signedInData: SignedInData,
             val hostedUIErrorData: HostedUIErrorData? = null,
             val globalSignOutErrorData: GlobalSignOutErrorData? = null
         ) : EventType()
 
         data class SignOutGloballyError(
+            val userId: String,
             val signedInData: SignedInData,
             val hostedUIErrorData: HostedUIErrorData? = null,
             val globalSignOutErrorData: GlobalSignOutErrorData? = null

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignOutEvent.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/events/SignOutEvent.kt
@@ -29,14 +29,19 @@ internal class SignOutEvent(
     override val time: Date? = null,
 ) : StateMachineEvent {
     sealed class EventType {
-        data class InvokeHostedUISignOut(val userId: String, val signOutData: SignOutData, val signedInData: SignedInData) : EventType()
+        data class InvokeHostedUISignOut(
+            val userId: String,
+            val signOutData: SignOutData,
+            val signedInData: SignedInData,
+        ) : EventType()
 
         data class SignOutLocally(
             val userId: String,
             val signedInData: SignedInData?,
             val hostedUIErrorData: HostedUIErrorData? = null,
             val globalSignOutErrorData: GlobalSignOutErrorData? = null,
-            val revokeTokenErrorData: RevokeTokenErrorData? = null
+            val revokeTokenErrorData: RevokeTokenErrorData? = null,
+            val signOutAllUsers: Boolean = false
         ) : EventType()
 
         data class SignOutGlobally(

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthenticationState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthenticationState.kt
@@ -30,11 +30,14 @@ import com.amplifyframework.statemachine.codegen.data.SignedOutData
 import com.amplifyframework.statemachine.codegen.events.AuthenticationEvent
 import com.amplifyframework.statemachine.codegen.events.AuthorizationEvent
 import com.amplifyframework.statemachine.codegen.events.SignOutEvent
+import kotlinx.serialization.Serializable
 
 internal sealed class AuthenticationState : State {
     data class NotConfigured(val id: String = "") : AuthenticationState()
     data class Configured(val id: String = "") : AuthenticationState()
     data class SigningIn(var signInState: SignInState = SignInState.NotStarted()) : AuthenticationState()
+
+    @Serializable
     data class SignedIn(val signedInData: SignedInData, val deviceMetadata: DeviceMetadata) : AuthenticationState()
     data class SigningOut(var signOutState: SignOutState = SignOutState.NotStarted()) : AuthenticationState()
     data class SignedOut(val signedOutData: SignedOutData) : AuthenticationState()
@@ -64,71 +67,92 @@ internal sealed class AuthenticationState : State {
                             val action = authenticationActions.configureAuthenticationAction(authenticationEvent)
                             StateResolution(Configured(), listOf(action))
                         }
+
                         authorizationEvent is AuthorizationEvent.EventType.StartFederationToIdentityPool -> {
                             StateResolution(FederatingToIdentityPool())
                         }
+
                         else -> defaultResolution
                     }
                 }
+
                 is Configured -> when (authenticationEvent) {
                     is AuthenticationEvent.EventType.InitializedSignedIn -> StateResolution(
                         SignedIn(authenticationEvent.signedInData, authenticationEvent.deviceMetadata)
                     )
+
                     is AuthenticationEvent.EventType.InitializedFederated -> StateResolution(
                         FederatedToIdentityPool()
                     )
+
                     is AuthenticationEvent.EventType.InitializedSignedOut -> StateResolution(
                         SignedOut(authenticationEvent.signedOutData)
                     )
+
                     is AuthenticationEvent.EventType.SignInRequested -> {
                         val action = authenticationActions.initiateSignInAction(authenticationEvent)
                         StateResolution(SigningIn(), listOf(action))
                     }
+
                     else -> defaultResolution
                 }
+
                 is SigningIn -> when (authenticationEvent) {
                     is AuthenticationEvent.EventType.SignInCompleted -> StateResolution(
                         SignedIn(authenticationEvent.signedInData, authenticationEvent.deviceMetadata)
                     )
+
                     is AuthenticationEvent.EventType.CancelSignIn -> {
                         if (authenticationEvent.error != null) {
                             StateResolution(Error(authenticationEvent.error))
                         }
                         StateResolution(SignedOut(SignedOutData()))
                     }
+
                     is AuthenticationEvent.EventType.ThrowError -> {
                         StateResolution(Error(authenticationEvent.exception))
                     }
+
                     else -> {
                         val resolution = signInResolver.resolve(oldState.signInState, event)
                         StateResolution(SigningIn(resolution.newState), resolution.actions)
                     }
                 }
+
                 is SignedIn -> when (authenticationEvent) {
                     is AuthenticationEvent.EventType.SignOutRequested -> {
                         val action =
-                            authenticationActions.initiateSignOutAction(authenticationEvent, oldState.signedInData)
+                            authenticationActions.initiateSignOutAction(
+                                oldState.signedInData.userId,
+                                authenticationEvent,
+                                oldState.signedInData
+                            )
                         StateResolution(SigningOut(), listOf(action))
                     }
+
                     else -> defaultResolution
                 }
+
                 is SigningOut -> {
                     val signOutEvent = event.isSignOutEvent()
                     when {
                         signOutEvent is SignOutEvent.EventType.SignedOutSuccess -> {
                             StateResolution(SignedOut(signOutEvent.signedOutData))
                         }
+
                         authenticationEvent is AuthenticationEvent.EventType.CancelSignOut -> {
                             StateResolution(
                                 SignedIn(authenticationEvent.signedInData, authenticationEvent.deviceMetadata)
                             )
                         }
+
                         else -> {
                             val resolution = signOutResolver.resolve(oldState.signOutState, event)
                             StateResolution(SigningOut(resolution.newState), resolution.actions)
                         }
                     }
                 }
+
                 is SignedOut -> {
                     val authorizationEvent = event.isAuthorizationEvent()
                     when {
@@ -136,57 +160,75 @@ internal sealed class AuthenticationState : State {
                             val action = authenticationActions.initiateSignInAction(authenticationEvent)
                             StateResolution(SigningIn(), listOf(action))
                         }
+
                         authenticationEvent is AuthenticationEvent.EventType.SignOutRequested -> {
                             val action = authenticationActions
-                                .initiateSignOutAction(authenticationEvent, null)
+                                .initiateSignOutAction(
+                                    authenticationEvent.signOutData.userId,
+                                    authenticationEvent,
+                                    null
+                                )
                             StateResolution(SigningOut(), listOf(action))
                         }
+
                         authorizationEvent is AuthorizationEvent.EventType.StartFederationToIdentityPool -> {
                             StateResolution(FederatingToIdentityPool())
                         }
+
                         else -> defaultResolution
                     }
                 }
+
                 is FederatingToIdentityPool -> {
                     when (val authorizationEvent = event.isAuthorizationEvent()) {
                         is AuthorizationEvent.EventType.Fetched -> {
                             StateResolution(FederatedToIdentityPool())
                         }
+
                         is AuthorizationEvent.EventType.ThrowError -> {
                             StateResolution(Error(authorizationEvent.exception))
                         }
+
                         else -> defaultResolution
                     }
                 }
+
                 is FederatedToIdentityPool -> {
                     val authorizationEvent = event.isAuthorizationEvent()
                     when {
                         authenticationEvent is AuthenticationEvent.EventType.ClearFederationToIdentityPool -> {
                             val action = authenticationActions.initiateSignOutAction(
-                                AuthenticationEvent.EventType.SignOutRequested(SignOutData()),
+                                authenticationEvent.userId,
+                                AuthenticationEvent.EventType.SignOutRequested(SignOutData(authenticationEvent.userId)),
                                 null
                             )
                             StateResolution(SigningOut(), listOf(action))
                         }
+
                         authorizationEvent is AuthorizationEvent.EventType.StartFederationToIdentityPool -> {
                             StateResolution(FederatingToIdentityPool())
                         }
+
                         else -> defaultResolution
                     }
                 }
+
                 is Error -> {
                     val authorizationEvent = event.isAuthorizationEvent()
                     when {
                         authorizationEvent is AuthorizationEvent.EventType.StartFederationToIdentityPool -> {
                             StateResolution(FederatingToIdentityPool())
                         }
+
                         authenticationEvent is AuthenticationEvent.EventType.ClearFederationToIdentityPool -> {
                             val action = authenticationActions.initiateSignOutAction(
-                                AuthenticationEvent.EventType.SignOutRequested(SignOutData()),
+                                authenticationEvent.userId,
+                                AuthenticationEvent.EventType.SignOutRequested(SignOutData(authenticationEvent.userId)),
                                 null
                             )
                             StateResolution(SigningOut(), listOf(action))
                         }
+
                         else -> defaultResolution
                     }
                 }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthenticationState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthenticationState.kt
@@ -123,9 +123,10 @@ internal sealed class AuthenticationState : State {
                     is AuthenticationEvent.EventType.SignOutRequested -> {
                         val action =
                             authenticationActions.initiateSignOutAction(
-                                oldState.signedInData.userId,
-                                authenticationEvent,
-                                oldState.signedInData
+                                userId = oldState.signedInData.userId,
+                                event = authenticationEvent,
+                                signedInData = oldState.signedInData,
+                                signOutAllUsers = authenticationEvent.signOutData.signOutAllUsers
                             )
                         StateResolution(SigningOut(), listOf(action))
                     }
@@ -164,9 +165,10 @@ internal sealed class AuthenticationState : State {
                         authenticationEvent is AuthenticationEvent.EventType.SignOutRequested -> {
                             val action = authenticationActions
                                 .initiateSignOutAction(
-                                    authenticationEvent.signOutData.userId,
-                                    authenticationEvent,
-                                    null
+                                    userId = authenticationEvent.signOutData.userId,
+                                    event = authenticationEvent,
+                                    signedInData = null,
+                                    signOutAllUsers = authenticationEvent.signOutData.signOutAllUsers
                                 )
                             StateResolution(SigningOut(), listOf(action))
                         }
@@ -198,9 +200,10 @@ internal sealed class AuthenticationState : State {
                     when {
                         authenticationEvent is AuthenticationEvent.EventType.ClearFederationToIdentityPool -> {
                             val action = authenticationActions.initiateSignOutAction(
-                                authenticationEvent.userId,
-                                AuthenticationEvent.EventType.SignOutRequested(SignOutData(authenticationEvent.userId)),
-                                null
+                                userId = authenticationEvent.userId,
+                                event = AuthenticationEvent.EventType.SignOutRequested(SignOutData(authenticationEvent.userId)),
+                                signedInData = null,
+                                signOutAllUsers = false
                             )
                             StateResolution(SigningOut(), listOf(action))
                         }
@@ -222,9 +225,10 @@ internal sealed class AuthenticationState : State {
 
                         authenticationEvent is AuthenticationEvent.EventType.ClearFederationToIdentityPool -> {
                             val action = authenticationActions.initiateSignOutAction(
-                                authenticationEvent.userId,
-                                AuthenticationEvent.EventType.SignOutRequested(SignOutData(authenticationEvent.userId)),
-                                null
+                                userId = authenticationEvent.userId,
+                                event = AuthenticationEvent.EventType.SignOutRequested(SignOutData(authenticationEvent.userId)),
+                                signedInData = null,
+                                signOutAllUsers = false
                             )
                             StateResolution(SigningOut(), listOf(action))
                         }

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthorizationState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/AuthorizationState.kt
@@ -151,8 +151,9 @@ internal sealed class AuthorizationState : State {
                 }
                 is SigningOut -> when {
                     event.isSignOutEvent() is SignOutEvent.EventType.SignOutLocally -> {
-                        val action = authorizationActions.persistCredentials(AmplifyCredential.Empty((event.isSignOutEvent() as SignOutEvent.EventType.SignOutLocally).userId))
-                        StateResolution(StoringCredentials(AmplifyCredential.Empty((event.isSignOutEvent() as SignOutEvent.EventType.SignOutLocally).userId)), listOf(action))
+                        val e = (event.isSignOutEvent() as SignOutEvent.EventType.SignOutLocally)
+                        val action = authorizationActions.persistCredentials(AmplifyCredential.Empty(e.userId, e.signOutAllUsers))
+                        StateResolution(StoringCredentials(AmplifyCredential.Empty(e.userId, e.signOutAllUsers)), listOf(action))
                     }
                     authenticationEvent is AuthenticationEvent.EventType.CancelSignOut -> {
                         StateResolution(SessionEstablished(oldState.amplifyCredential))

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/DeleteUserState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/DeleteUserState.kt
@@ -45,7 +45,7 @@ internal sealed class DeleteUserState : State {
                 is NotStarted, is Error -> {
                     when (deleteUserEvent) {
                         is DeleteUserEvent.EventType.DeleteUser -> {
-                            val action = deleteUserActions.initDeleteUserAction(deleteUserEvent.accessToken)
+                            val action = deleteUserActions.initDeleteUserAction(deleteUserEvent.accessToken, deleteUserEvent.userId)
                             StateResolution(DeletingUser(), listOf(action))
                         }
                         else -> StateResolution(oldState)
@@ -54,12 +54,12 @@ internal sealed class DeleteUserState : State {
                 is DeletingUser -> {
                     when (deleteUserEvent) {
                         is DeleteUserEvent.EventType.UserDeleted -> {
-                            val action = deleteUserActions.initiateSignOut()
+                            val action = deleteUserActions.initiateSignOut(deleteUserEvent.userId)
                             StateResolution(UserDeleted(), listOf(action))
                         }
                         is DeleteUserEvent.EventType.ThrowError -> {
                             if (deleteUserEvent.signOutUser) {
-                                val action = deleteUserActions.initiateSignOut()
+                                val action = deleteUserActions.initiateSignOut(deleteUserEvent.userId)
                                 StateResolution(UserDeleted(), listOf(action))
                             } else {
                                 StateResolution(Error(deleteUserEvent.exception))

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignOutState.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/codegen/states/SignOutState.kt
@@ -27,6 +27,7 @@ import com.amplifyframework.statemachine.codegen.data.SignedInData
 import com.amplifyframework.statemachine.codegen.data.SignedOutData
 import com.amplifyframework.statemachine.codegen.events.AuthEvent
 import com.amplifyframework.statemachine.codegen.events.SignOutEvent
+import kotlin.math.sign
 
 internal sealed class SignOutState : State {
     data class NotStarted(val id: String = "") : SignOutState()
@@ -52,7 +53,7 @@ internal sealed class SignOutState : State {
             return when (oldState) {
                 is NotStarted -> when (signOutEvent) {
                     is SignOutEvent.EventType.InvokeHostedUISignOut -> {
-                        val action = signOutActions.hostedUISignOutAction(signOutEvent)
+                        val action = signOutActions.hostedUISignOutAction(signOutEvent.userId, signOutEvent)
                         StateResolution(
                             SigningOutHostedUI(
                                 signOutEvent.signedInData,
@@ -63,7 +64,7 @@ internal sealed class SignOutState : State {
                         )
                     }
                     is SignOutEvent.EventType.SignOutGlobally -> {
-                        val action = signOutActions.globalSignOutAction(signOutEvent)
+                        val action = signOutActions.globalSignOutAction(signOutEvent.userId, signOutEvent)
                         StateResolution(SigningOutGlobally(), listOf(action))
                     }
                     is SignOutEvent.EventType.RevokeToken -> {
@@ -78,7 +79,7 @@ internal sealed class SignOutState : State {
                 }
                 is SigningOutHostedUI -> when (signOutEvent) {
                     is SignOutEvent.EventType.SignOutGlobally -> {
-                        val action = signOutActions.globalSignOutAction(signOutEvent)
+                        val action = signOutActions.globalSignOutAction(signOutEvent.userId, signOutEvent)
                         StateResolution(SigningOutGlobally(), listOf(action))
                     }
                     is SignOutEvent.EventType.RevokeToken -> {

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/util/ThreadSafeLifoMap.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/statemachine/util/ThreadSafeLifoMap.kt
@@ -1,0 +1,129 @@
+package com.amplifyframework.statemachine.util
+
+/**
+ * A thread-safe map that mimics the behavior of a stack (Last-In-First-Out, LIFO).
+ *
+ * @param K The type of keys maintained by this map.
+ * @param V The type of values maintained by this map.
+ * @property maxSize The maximum number of elements allowed in the map.
+ *                   If null, the map has no size limit.
+ */
+class LifoMap<K, V>(private val maxSize: Int? = null) {
+
+    // Internal map to maintain the key-value pairs with insertion order.
+    private val map = LinkedHashMap<K, V>()
+
+    /**
+     * Adds a key-value pair to the map. If the map exceeds the maximum size,
+     * the oldest entry (first inserted) is removed to maintain the size constraint.
+     *
+     * @param key The key to add to the map.
+     * @param value The value associated with the key.
+     */
+    @Synchronized
+    fun push(key: K, value: V) {
+        if (maxSize != null && map.size >= maxSize) {
+            map.remove(map.keys.first()) // Remove the oldest entry to maintain size
+        }
+        map[key] = value
+    }
+
+    /**
+     * Removes and returns the value associated with the most recently added key.
+     *
+     * @return The value of the last inserted key, or null if the map is empty.
+     */
+    @Synchronized
+    fun pop(): V? {
+        val lastKey = map.keys.lastOrNull() ?: return null
+        return map.remove(lastKey)
+    }
+
+    /**
+     * Removes and returns the value associated with the specified key.
+     */
+    @Synchronized
+    fun pop(key: K): V? {
+        return map.remove(key)
+    }
+
+    /**
+     * Returns the value associated with the most recently added key
+     * without removing it from the map.
+     *
+     * @return The value of the last inserted key, or null if the map is empty.
+     */
+    @Synchronized
+    fun peek(): V? {
+        val lastKey = map.keys.lastOrNull() ?: return null
+        return map[lastKey]
+    }
+
+    /**
+     * Returns the key associated with the most recently added value
+     * without removing it from the map.
+     *
+     * @return The key of the last inserted value, or null if the map is empty.
+     */
+    @Synchronized
+    fun peekKey(): K? {
+        return map.keys.lastOrNull()
+    }
+
+    /**
+     * Returns the value associated with the specified key.
+     */
+    @Synchronized
+    fun get(key: K): V? {
+        return map[key]
+    }
+
+    /**
+     * Checks if the map contains the specified key.
+     */
+    @Synchronized
+    fun containsKey(key: K): Boolean {
+        return map.containsKey(key)
+    }
+
+    /**
+     * Checks if the map is empty.
+     *
+     * @return True if the map contains no elements, false otherwise.
+     */
+    fun isEmpty(): Boolean = map.isEmpty()
+
+    /**
+     * Returns the current number of elements in the map.
+     *
+     * @return The number of key-value pairs in the map.
+     */
+    fun size(): Int = map.size
+
+    /**
+     * Removes all key-value pairs from the map.
+     */
+    fun clear() {
+        map.clear()
+    }
+
+    /**
+     * Returns a string representation of the map.
+     *
+     * @return A string representation of the map in insertion order.
+     */
+    override fun toString(): String = map.toString()
+
+    companion object {
+        /**
+         * Creates a new LifoMap with no size limit.
+         *
+         * @return A new LifoMap instance.
+         */
+        fun <K, V> empty(): LifoMap<K, V> = LifoMap()
+    }
+}
+
+fun <K, V> LifoMap<K, V>.getOrDefault(key: K, defaultValue: V): V {
+    return get(key) ?: defaultValue
+}

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginFeatureTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginFeatureTest.kt
@@ -190,7 +190,13 @@ class AWSCognitoAuthPluginFeatureTest(private val testCase: FeatureTestCase) {
 
         authStateMachine = AuthStateMachine(authEnvironment, getState(feature.preConditions.state))
 
-        return RealAWSCognitoAuthPlugin(authConfiguration, authEnvironment, authStateMachine, logger)
+        return RealAWSCognitoAuthPlugin(
+            authConfiguration,
+            authEnvironment,
+            authStateMachine,
+            logger,
+            userId
+        )
     }
 
     private fun verify(validation: ExpectationShapes) {

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -609,9 +609,9 @@ class AWSCognitoAuthPluginTest {
     fun verifySignOut() {
         val expectedOnComplete = Consumer<AuthSignOutResult> { }
 
-        authPlugin.signOut(expectedOnComplete)
+        authPlugin.signOut("username-testing","testing",expectedOnComplete)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.signOut(any()) }
+        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.signOut("username-testing","testing",any()) }
     }
 
     @Test
@@ -619,9 +619,9 @@ class AWSCognitoAuthPluginTest {
         val expectedOptions = AuthSignOutOptions.builder().build()
         val expectedOnComplete = Consumer<AuthSignOutResult> { }
 
-        authPlugin.signOut(expectedOptions, expectedOnComplete)
+        authPlugin.signOut("username-testing","testing", expectedOptions, expectedOnComplete)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.signOut(expectedOptions, any()) }
+        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.signOut("username-testing","testing",expectedOptions, any()) }
     }
 
     @Test
@@ -684,9 +684,16 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Action { }
         val expectedOnError = Consumer<AuthException> { }
 
-        authPlugin.clearFederationToIdentityPool(expectedOnSuccess, expectedOnError)
+        authPlugin.clearFederationToIdentityPool("username-testing", "testing", expectedOnSuccess, expectedOnError)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.clearFederationToIdentityPool(any(), any()) }
+        verify(timeout = CHANNEL_TIMEOUT) {
+            realPlugin.clearFederationToIdentityPool(
+                "username-testing",
+                "testing",
+                any(),
+                any()
+            )
+        }
     }
 
     @Test

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -609,9 +609,9 @@ class AWSCognitoAuthPluginTest {
     fun verifySignOut() {
         val expectedOnComplete = Consumer<AuthSignOutResult> { }
 
-        authPlugin.signOut("username-testing","testing",expectedOnComplete)
+        authPlugin.signOut("testing", expectedOnComplete)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.signOut("username-testing","testing",any()) }
+        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.signOut("testing", any()) }
     }
 
     @Test
@@ -619,9 +619,9 @@ class AWSCognitoAuthPluginTest {
         val expectedOptions = AuthSignOutOptions.builder().build()
         val expectedOnComplete = Consumer<AuthSignOutResult> { }
 
-        authPlugin.signOut("username-testing","testing", expectedOptions, expectedOnComplete)
+        authPlugin.signOut("testing", expectedOptions, expectedOnComplete)
 
-        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.signOut("username-testing","testing",expectedOptions, any()) }
+        verify(timeout = CHANNEL_TIMEOUT) { realPlugin.signOut("testing", expectedOptions, any()) }
     }
 
     @Test
@@ -684,11 +684,10 @@ class AWSCognitoAuthPluginTest {
         val expectedOnSuccess = Action { }
         val expectedOnError = Consumer<AuthException> { }
 
-        authPlugin.clearFederationToIdentityPool("username-testing", "testing", expectedOnSuccess, expectedOnError)
+        authPlugin.clearFederationToIdentityPool("testing", expectedOnSuccess, expectedOnError)
 
         verify(timeout = CHANNEL_TIMEOUT) {
             realPlugin.clearFederationToIdentityPool(
-                "username-testing",
                 "testing",
                 any(),
                 any()

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
@@ -442,7 +442,7 @@ class AuthValidationTest {
     }
 
     private fun signOut() = blockForResult { complete ->
-        plugin.signOut("","",complete)
+        plugin.signOut("", complete)
     }
 
     private fun signInHostedUi(): AuthSignInResult {
@@ -459,7 +459,7 @@ class AuthValidationTest {
     }
 
     private fun signOutHostedUi() = blockForResult { complete ->
-        plugin.signOut("","",complete)
+        plugin.signOut("", complete)
     }
 
     private fun assertSignedOut() {

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
@@ -131,7 +131,8 @@ class AuthValidationTest {
         configuration = configuration,
         authEnvironment = environment,
         authStateMachine = stateMachine,
-        logger = logger
+        logger = logger,
+        userId = userId
     )
 
     private val mainThreadSurrogate = newSingleThreadContext("Main thread")
@@ -441,7 +442,7 @@ class AuthValidationTest {
     }
 
     private fun signOut() = blockForResult { complete ->
-        plugin.signOut(complete)
+        plugin.signOut("","",complete)
     }
 
     private fun signInHostedUi(): AuthSignInResult {
@@ -458,7 +459,7 @@ class AuthValidationTest {
     }
 
     private fun signOutHostedUi() = blockForResult { complete ->
-        plugin.signOut(complete)
+        plugin.signOut("","",complete)
     }
 
     private fun assertSignedOut() {

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/RealAWSCognitoAuthPluginTest.kt
@@ -176,7 +176,8 @@ class RealAWSCognitoAuthPluginTest {
             authConfiguration,
             authEnvironment,
             authStateMachine,
-            logger
+            logger,
+            "userId-testing",
         )
 
         mockkStatic("com.amplifyframework.auth.cognito.AWSCognitoAuthSessionKt")

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/authstategenerators/AuthStateJsonGenerator.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/featuretest/generators/authstategenerators/AuthStateJsonGenerator.kt
@@ -67,7 +67,7 @@ object AuthStateJsonGenerator : SerializableProvider {
             idToken = dummyToken,
             accessToken = dummyToken,
             refreshToken = dummyToken,
-            expiration = 300
+            expiration = 300,
         )
     )
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/StateMachineForAuthListenerTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/StateMachineForAuthListenerTests.kt
@@ -33,7 +33,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
-class StateMachineListenerTests {
+class StateMachineForAuthListenerTests {
     private val mainThreadSurrogate = newSingleThreadContext("Main thread")
     private lateinit var stateMachine: CounterStateMachine
 

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/StateMachineForAuthTests.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/statemachine/StateMachineForAuthTests.kt
@@ -33,7 +33,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
-class StateMachineTests {
+class StateMachineForAuthTests {
 
     private val timeout = 1.seconds
     private val mainThreadSurrogate = newSingleThreadContext("Main thread")

--- a/aws-auth-plugins-core/build.gradle.kts
+++ b/aws-auth-plugins-core/build.gradle.kts
@@ -27,7 +27,13 @@ group = properties["POM_GROUP"].toString()
 android {
     namespace = "com.amplifyframework.plugins.core"
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 

--- a/aws-core/build.gradle.kts
+++ b/aws-core/build.gradle.kts
@@ -28,6 +28,12 @@ android {
     kotlinOptions {
         moduleName = "com.amplifyframework.aws-core"
     }
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {

--- a/aws-datastore/build.gradle.kts
+++ b/aws-datastore/build.gradle.kts
@@ -25,6 +25,12 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.datastore"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -64,5 +70,5 @@ dependencies {
 }
 
 afterEvaluate {
-    android.kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
+    android.kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
 }

--- a/aws-geo-location/build.gradle.kts
+++ b/aws-geo-location/build.gradle.kts
@@ -24,6 +24,12 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.geo.location"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -45,5 +51,5 @@ dependencies {
 }
 
 afterEvaluate {
-    android.kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
+    android.kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
 }

--- a/aws-logging-cloudwatch/build.gradle.kts
+++ b/aws-logging-cloudwatch/build.gradle.kts
@@ -26,6 +26,12 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.logging.cloudwatch"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -64,5 +70,5 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }

--- a/aws-pinpoint-core/build.gradle.kts
+++ b/aws-pinpoint-core/build.gradle.kts
@@ -26,6 +26,12 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.pinpoint.core"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -51,5 +57,5 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }

--- a/aws-predictions-tensorflow/build.gradle.kts
+++ b/aws-predictions-tensorflow/build.gradle.kts
@@ -25,6 +25,12 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.predictions.tensorflow"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {

--- a/aws-predictions/build.gradle.kts
+++ b/aws-predictions/build.gradle.kts
@@ -26,6 +26,12 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.predictions.aws"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -58,5 +64,5 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }

--- a/aws-push-notifications-pinpoint-common/build.gradle.kts
+++ b/aws-push-notifications-pinpoint-common/build.gradle.kts
@@ -26,7 +26,13 @@ group = properties["POM_GROUP"].toString()
 android {
     namespace = "com.amplifyframework.pushnotifications.pinpoint.common"
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 

--- a/aws-push-notifications-pinpoint/build.gradle.kts
+++ b/aws-push-notifications-pinpoint/build.gradle.kts
@@ -25,6 +25,12 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.pushnotifications.pinpoint"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {

--- a/aws-storage-s3/build.gradle.kts
+++ b/aws-storage-s3/build.gradle.kts
@@ -31,6 +31,12 @@ android {
     testOptions {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -68,5 +74,5 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -158,13 +158,13 @@ fun Project.configureAndroid() {
 
             compileOptions {
                 isCoreLibraryDesugaringEnabled = true
-                sourceCompatibility = JavaVersion.VERSION_11
-                targetCompatibility = JavaVersion.VERSION_11
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
             }
 
             tasks.withType<KotlinCompile>().configureEach {
                 kotlinOptions {
-                    jvmTarget = JavaVersion.VERSION_11.toString()
+                    jvmTarget = JavaVersion.VERSION_17.toString()
                 }
             }
 

--- a/common-core/build.gradle.kts
+++ b/common-core/build.gradle.kts
@@ -26,4 +26,10 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.common.core"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }

--- a/core-kotlin/build.gradle.kts
+++ b/core-kotlin/build.gradle.kts
@@ -23,6 +23,12 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.kotlin"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -41,6 +47,6 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
     freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
 }

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
@@ -281,7 +281,7 @@ class KotlinAuthFacade(private val delegate: Delegate = Amplify.Auth) : Auth {
     }
 
     override suspend fun signOut(options: AuthSignOutOptions): AuthSignOutResult = suspendCoroutine { continuation ->
-        delegate.signOut(options) { continuation.resume(it) }
+        delegate.signOut("","", options) { continuation.resume(it) }
     }
 
     override suspend fun deleteUser() = suspendCoroutine { continuation ->

--- a/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
+++ b/core-kotlin/src/main/java/com/amplifyframework/kotlin/auth/KotlinAuthFacade.kt
@@ -281,7 +281,7 @@ class KotlinAuthFacade(private val delegate: Delegate = Amplify.Auth) : Auth {
     }
 
     override suspend fun signOut(options: AuthSignOutOptions): AuthSignOutResult = suspendCoroutine { continuation ->
-        delegate.signOut("","", options) { continuation.resume(it) }
+        delegate.signOut("", options) { continuation.resume(it) }
     }
 
     override suspend fun deleteUser() = suspendCoroutine { continuation ->

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -923,7 +923,7 @@ class KotlinAuthFacadeTest {
         val expected = AuthSignOutResult()
         var onCompleteConsumer: Consumer<AuthSignOutResult>? = null
         every {
-            delegate.signOut(any(), any())
+            delegate.signOut("","", any(), any())
         } answers {
             val indexOfCompletionAction = 1
             onCompleteConsumer = it.invocation.args[indexOfCompletionAction] as Consumer<AuthSignOutResult>
@@ -933,7 +933,7 @@ class KotlinAuthFacadeTest {
         // Since nothing returned, just verify it called through.
         assertNotNull(onCompleteConsumer)
         verify {
-            delegate.signOut(any(), onCompleteConsumer!!)
+            delegate.signOut("","", any(), onCompleteConsumer!!)
         }
     }
 

--- a/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
+++ b/core-kotlin/src/test/java/com/amplifyframework/kotlin/auth/KotlinAuthFacadeTest.kt
@@ -357,7 +357,7 @@ class KotlinAuthFacadeTest {
     fun fetchAuthSessionSucceeds() = runBlocking {
         val session = AuthSession(true)
         every {
-            delegate.fetchAuthSession(any(), any(), any())
+            delegate.fetchAuthSession(any(), any())
         } answers {
             val indexOfResultConsumer = 1
             val onResult = it.invocation.args[indexOfResultConsumer] as Consumer<AuthSession>
@@ -374,7 +374,7 @@ class KotlinAuthFacadeTest {
         val options = AuthFetchSessionOptions.builder().forceRefresh(true).build()
         val session = AuthSession(true)
         every {
-            delegate.fetchAuthSession(any(), any(), any())
+            delegate.fetchAuthSession(any(), any())
         } answers {
             val indexOfResultConsumer = 1
             val onResult = it.invocation.args[indexOfResultConsumer] as Consumer<AuthSession>
@@ -396,7 +396,7 @@ class KotlinAuthFacadeTest {
     fun fetchAuthSessionThrows(): Unit = runBlocking {
         val error = AuthException("uh", "oh")
         every {
-            delegate.fetchAuthSession(any(), any(), any())
+            delegate.fetchAuthSession( any(), any())
         } answers {
             val indexOfErrorConsumer = 2
             val onError = it.invocation.args[indexOfErrorConsumer] as Consumer<AuthException>
@@ -413,7 +413,7 @@ class KotlinAuthFacadeTest {
     fun fetchAuthSessionThrowsSessionExpired(): Unit = runBlocking {
         val error = SessionExpiredException() as AuthException
         every {
-            delegate.fetchAuthSession(any(), any(), any())
+            delegate.fetchAuthSession(any(), any())
         } answers {
             val indexOfErrorConsumer = 2
             val onError = it.invocation.args[indexOfErrorConsumer] as Consumer<AuthException>
@@ -923,7 +923,7 @@ class KotlinAuthFacadeTest {
         val expected = AuthSignOutResult()
         var onCompleteConsumer: Consumer<AuthSignOutResult>? = null
         every {
-            delegate.signOut("","", any(), any())
+            delegate.signOut("", any(), any())
         } answers {
             val indexOfCompletionAction = 1
             onCompleteConsumer = it.invocation.args[indexOfCompletionAction] as Consumer<AuthSignOutResult>
@@ -933,7 +933,7 @@ class KotlinAuthFacadeTest {
         // Since nothing returned, just verify it called through.
         assertNotNull(onCompleteConsumer)
         verify {
-            delegate.signOut("","", any(), onCompleteConsumer!!)
+            delegate.signOut("", any(), onCompleteConsumer!!)
         }
     }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -29,6 +29,12 @@ android {
     kotlinOptions {
         moduleName = "com.amplifyframework.core"
     }
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -68,7 +74,7 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }
 
 afterEvaluate {

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -212,12 +212,11 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
 
     @Override
     public void fetchAuthSession(
-            @NonNull String username,
             @NonNull String userId,
             @NonNull Consumer<AuthSession> onSuccess,
             @NonNull Consumer<AuthException> onError
     ) {
-        getSelectedPlugin().fetchAuthSession(username, userId, onSuccess, onError);
+        getSelectedPlugin().fetchAuthSession(userId, onSuccess, onError);
     }
 
     @Override
@@ -393,16 +392,16 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
     }
 
     @Override
-    public void signOut(@NonNull String username, @NonNull String userId, @NonNull Consumer<AuthSignOutResult> onComplete) {
-        getSelectedPlugin().signOut(username, userId, onComplete);
+    public void signOut(@NonNull String userId, @NonNull Consumer<AuthSignOutResult> onComplete) {
+        getSelectedPlugin().signOut(userId, onComplete);
     }
 
     @Override
     public void signOut(
-            @NonNull String username, @NonNull String userId, @NonNull AuthSignOutOptions options,
+            @NonNull String userId, @NonNull AuthSignOutOptions options,
             @NonNull Consumer<AuthSignOutResult> onComplete
     ) {
-        getSelectedPlugin().signOut(username, userId, options, onComplete);
+        getSelectedPlugin().signOut(userId, options, onComplete);
     }
 
     @Override

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -17,6 +17,7 @@ package com.amplifyframework.auth;
 
 import android.app.Activity;
 import android.content.Intent;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -211,6 +212,16 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
 
     @Override
     public void fetchAuthSession(
+            @NonNull String username,
+            @NonNull String userId,
+            @NonNull Consumer<AuthSession> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().fetchAuthSession(username, userId, onSuccess, onError);
+    }
+
+    @Override
+    public void fetchAuthSession(
             @NonNull Consumer<AuthSession> onSuccess,
             @NonNull Consumer<AuthException> onError
     ) {
@@ -382,15 +393,16 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
     }
 
     @Override
-    public void signOut(@NonNull Consumer<AuthSignOutResult> onComplete) {
-        getSelectedPlugin().signOut(onComplete);
+    public void signOut(@NonNull String username, @NonNull String userId, @NonNull Consumer<AuthSignOutResult> onComplete) {
+        getSelectedPlugin().signOut(username, userId, onComplete);
     }
 
-    @Override public void signOut(
-            @NonNull AuthSignOutOptions options,
+    @Override
+    public void signOut(
+            @NonNull String username, @NonNull String userId, @NonNull AuthSignOutOptions options,
             @NonNull Consumer<AuthSignOutResult> onComplete
     ) {
-        getSelectedPlugin().signOut(options, onComplete);
+        getSelectedPlugin().signOut(username, userId, options, onComplete);
     }
 
     @Override

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -405,6 +405,11 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
     }
 
     @Override
+    public void signOut(@NonNull Consumer<AuthSignOutResult> onComplete) {
+        getSelectedPlugin().signOut(onComplete);
+    }
+
+    @Override
     public void deleteUser(
             @NonNull Action onSuccess,
             @NonNull Consumer<AuthException> onError) {

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategory.java
@@ -203,11 +203,21 @@ public final class AuthCategory extends Category<AuthPlugin<?>> implements AuthC
 
     @Override
     public void fetchAuthSession(
+            @NonNull String userId,
             @NonNull AuthFetchSessionOptions options,
             @NonNull Consumer<AuthSession> onSuccess,
             @NonNull Consumer<AuthException> onError
     ) {
-        getSelectedPlugin().fetchAuthSession(options, onSuccess, onError);
+        getSelectedPlugin().fetchAuthSession(userId, options, onSuccess, onError);
+    }
+
+    @Override
+    public void fetchAuthSession(
+            @NonNull AuthFetchSessionOptions options,
+            @NonNull Consumer<AuthSession> onSuccess,
+            @NonNull Consumer<AuthException> onError
+    ) {
+        getSelectedPlugin().fetchAuthSession("", options, onSuccess, onError);
     }
 
     @Override

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -269,7 +269,6 @@ public interface AuthCategoryBehavior {
      * @param onError   Error callback
      */
     void fetchAuthSession(
-            @NonNull String username,
             @NonNull String userId,
             @NonNull Consumer<AuthSession> onSuccess,
             @NonNull Consumer<AuthException> onError);
@@ -549,18 +548,16 @@ public interface AuthCategoryBehavior {
      *
      * @param onComplete Complete callback
      */
-    void signOut(@NonNull String username, @NonNull String userId, @NonNull Consumer<AuthSignOutResult> onComplete);
+    void signOut(@NonNull String userId, @NonNull Consumer<AuthSignOutResult> onComplete);
 
     /**
      * Sign out with advanced options.
      *
-     * @param username
      * @param userId
      * @param options    Advanced options for sign out (e.g. whether to sign out of all devices globally)
      * @param onComplete Complete callback
      */
     void signOut(
-            @NonNull String username,
             @NonNull String userId,
             @NonNull AuthSignOutOptions options,
             @NonNull Consumer<AuthSignOutResult> onComplete

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -17,6 +17,7 @@ package com.amplifyframework.auth;
 
 import android.app.Activity;
 import android.content.Intent;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -57,11 +58,12 @@ public interface AuthCategoryBehavior {
      * Creates a new user account with the specified username and password.
      * Can also pass in user attributes to associate with the user through
      * the options object.
-     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
-     * @param password The user's password
-     * @param options Advanced options such as additional attributes of the user or validation data
+     *
+     * @param username  A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param password  The user's password
+     * @param options   Advanced options such as additional attributes of the user or validation data
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void signUp(
             @NonNull String username,
@@ -73,11 +75,12 @@ public interface AuthCategoryBehavior {
     /**
      * If you have attribute confirmation enabled, this will allow the user
      * to enter the confirmation code they received to activate their account.
-     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     *
+     * @param username         A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
      * @param confirmationCode The confirmation code the user received
-     * @param options Advanced options such as a map of auth information for custom auth
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param options          Advanced options such as a map of auth information for custom auth
+     * @param onSuccess        Success callback
+     * @param onError          Error callback
      */
     void confirmSignUp(
             @NonNull String username,
@@ -89,10 +92,11 @@ public interface AuthCategoryBehavior {
     /**
      * If you have attribute confirmation enabled, this will allow the user
      * to enter the confirmation code they received to activate their account.
-     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     *
+     * @param username         A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
      * @param confirmationCode The confirmation code the user received
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onSuccess        Success callback
+     * @param onError          Error callback
      */
     void confirmSignUp(
             @NonNull String username,
@@ -103,10 +107,11 @@ public interface AuthCategoryBehavior {
     /**
      * If the user's code expires or they just missed it, this method can
      * be used to send them a new one.
-     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
-     * @param options Advanced options such as a map of auth information for custom auth
+     *
+     * @param username  A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param options   Advanced options such as a map of auth information for custom auth
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void resendSignUpCode(
             @NonNull String username,
@@ -117,9 +122,10 @@ public interface AuthCategoryBehavior {
     /**
      * If the user's code expires or they just missed it, this method can
      * be used to send them a new one.
-     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     *
+     * @param username  A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void resendSignUpCode(
             @NonNull String username,
@@ -129,11 +135,12 @@ public interface AuthCategoryBehavior {
     /**
      * Basic authentication to the app with a username and password or, if custom auth is setup,
      * you can send null for those and the necessary authentication details in the options object.
-     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
-     * @param password User's password for normal signup, null if custom auth or passwordless configurations are setup
-     * @param options Advanced options such as a map of auth information for custom auth
+     *
+     * @param username  A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param password  User's password for normal signup, null if custom auth or passwordless configurations are setup
+     * @param options   Advanced options such as a map of auth information for custom auth
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void signIn(
             @Nullable String username,
@@ -144,10 +151,11 @@ public interface AuthCategoryBehavior {
 
     /**
      * Basic authentication to the app with a username and password.
-     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
-     * @param password User's password
+     *
+     * @param username  A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param password  User's password
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void signIn(
             @Nullable String username,
@@ -157,10 +165,11 @@ public interface AuthCategoryBehavior {
 
     /**
      * Submit the confirmation code received as part of multi-factor Authentication during sign in.
+     *
      * @param challengeResponse The code received as part of the multi-factor authentication process
-     * @param options Advanced options such as a map of auth information for custom auth
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param options           Advanced options such as a map of auth information for custom auth
+     * @param onSuccess         Success callback
+     * @param onError           Error callback
      */
     void confirmSignIn(
             @NonNull String challengeResponse,
@@ -170,9 +179,10 @@ public interface AuthCategoryBehavior {
 
     /**
      * Submit the confirmation code received as part of multi-factor Authentication during sign in.
+     *
      * @param challengeResponse The code received as part of the multi-factor authentication process
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onSuccess         Success callback
+     * @param onError           Error callback
      */
     void confirmSignIn(
             @NonNull String challengeResponse,
@@ -183,10 +193,11 @@ public interface AuthCategoryBehavior {
      * Launch the specified auth provider's web UI sign in experience. You should also put the
      * {@link #handleWebUISignInResponse(Intent)} method in your activity's onNewIntent method to
      * capture the response which comes back from the UI flow.
-     * @param provider The auth provider you want to launch the web ui for (e.g. Facebook, Google, etc.)
+     *
+     * @param provider        The auth provider you want to launch the web ui for (e.g. Facebook, Google, etc.)
      * @param callingActivity The activity in your app you are calling this from
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onSuccess       Success callback
+     * @param onError         Error callback
      */
     void signInWithSocialWebUI(
             @NonNull AuthProvider provider,
@@ -198,11 +209,12 @@ public interface AuthCategoryBehavior {
      * Launch the specified auth provider's web UI sign in experience. You should also put the
      * {@link #handleWebUISignInResponse(Intent)} method in your activity's onNewIntent method to
      * capture the response which comes back from the UI flow.
-     * @param provider The auth provider you want to launch the web ui for (e.g. Facebook, Google, etc.)
+     *
+     * @param provider        The auth provider you want to launch the web ui for (e.g. Facebook, Google, etc.)
      * @param callingActivity The activity in your app you are calling this from
-     * @param options Advanced options for signing in with an auth provider's hosted web ui.
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param options         Advanced options for signing in with an auth provider's hosted web ui.
+     * @param onSuccess       Success callback
+     * @param onError         Error callback
      */
     void signInWithSocialWebUI(
             @NonNull AuthProvider provider,
@@ -214,9 +226,10 @@ public interface AuthCategoryBehavior {
     /**
      * Launch a hosted web sign in UI flow. You should also put the {@link #handleWebUISignInResponse(Intent)} method in
      * your activity's onNewIntent method to capture the response which comes back from the UI flow.
+     *
      * @param callingActivity The activity in your app you are calling this from
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onSuccess       Success callback
+     * @param onError         Error callback
      */
     void signInWithWebUI(
             @NonNull Activity callingActivity,
@@ -226,10 +239,11 @@ public interface AuthCategoryBehavior {
     /**
      * Launch a hosted web sign in UI flow. You should also put the {@link #handleWebUISignInResponse(Intent)}
      * method in your activity's onNewIntent method to capture the response which comes back from the UI flow.
+     *
      * @param callingActivity The activity in your app you are calling this from
-     * @param options Advanced options for signing in with a hosted web ui.
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param options         Advanced options for signing in with a hosted web ui.
+     * @param onSuccess       Success callback
+     * @param onError         Error callback
      */
     void signInWithWebUI(
             @NonNull Activity callingActivity,
@@ -239,6 +253,7 @@ public interface AuthCategoryBehavior {
 
     /**
      * Handles the response which comes back from {@link #signInWithWebUI(Activity, Consumer, Consumer)}.
+     *
      * @param intent The app activity's intent
      */
     void handleWebUISignInResponse(Intent intent);
@@ -249,8 +264,25 @@ public interface AuthCategoryBehavior {
      * to that plugin which contains the various security tokens and other identifying information if you want to
      * manually use them outside the plugin. Within Amplify this should not be needed as the other categories will
      * automatically work as long as you are signed in.
+     *
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
+     */
+    void fetchAuthSession(
+            @NonNull String username,
+            @NonNull String userId,
+            @NonNull Consumer<AuthSession> onSuccess,
+            @NonNull Consumer<AuthException> onError);
+
+    /**
+     * Retrieve the user's current session information - by default just whether they are signed out or in.
+     * Depending on how a plugin implements this, the resulting AuthSession can also be cast to a type specific
+     * to that plugin which contains the various security tokens and other identifying information if you want to
+     * manually use them outside the plugin. Within Amplify this should not be needed as the other categories will
+     * automatically work as long as you are signed in.
+     *
+     * @param onSuccess Success callback
+     * @param onError   Error callback
      */
     void fetchAuthSession(
             @NonNull Consumer<AuthSession> onSuccess,
@@ -262,9 +294,10 @@ public interface AuthCategoryBehavior {
      * to that plugin which contains the various security tokens and other identifying information if you want to
      * manually use them outside the plugin. Within Amplify this should not be needed as the other categories will
      * automatically work as long as you are signed in.
-     * @param options Advanced options for force refresh session.
+     *
+     * @param options   Advanced options for force refresh session.
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void fetchAuthSession(
             @NonNull AuthFetchSessionOptions options,
@@ -273,8 +306,9 @@ public interface AuthCategoryBehavior {
 
     /**
      * Remember the user device that is currently being used.
+     *
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void rememberDevice(
             @NonNull Action onSuccess,
@@ -283,8 +317,9 @@ public interface AuthCategoryBehavior {
     /**
      * Forget the user device that is currently being used from the list
      * of remembered devices.
+     *
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void forgetDevice(
             @NonNull Action onSuccess,
@@ -292,9 +327,10 @@ public interface AuthCategoryBehavior {
 
     /**
      * Forget a specific user device from the list of remembered devices.
-     * @param device Auth device to forget
+     *
+     * @param device    Auth device to forget
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void forgetDevice(
             @NonNull AuthDevice device,
@@ -303,8 +339,9 @@ public interface AuthCategoryBehavior {
 
     /**
      * Obtain a list of devices that are being tracked by the category.
+     *
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void fetchDevices(
             @NonNull Consumer<List<AuthDevice>> onSuccess,
@@ -312,10 +349,11 @@ public interface AuthCategoryBehavior {
 
     /**
      * Trigger password recovery for the given username.
-     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
-     * @param options Advanced options such as a map of auth information for custom auth
+     *
+     * @param username  A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param options   Advanced options such as a map of auth information for custom auth
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void resetPassword(
             @NonNull String username,
@@ -325,9 +363,10 @@ public interface AuthCategoryBehavior {
 
     /**
      * Trigger password recovery for the given username.
-     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     *
+     * @param username  A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void resetPassword(
             @NonNull String username,
@@ -336,12 +375,13 @@ public interface AuthCategoryBehavior {
 
     /**
      * Complete password recovery process by inputting user's desired new password and confirmation code.
-     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
-     * @param newPassword The user's desired new password
+     *
+     * @param username         A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param newPassword      The user's desired new password
      * @param confirmationCode The confirmation code the user received after starting the forgotPassword process
-     * @param options Advanced options such as a map of auth information for custom auth
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param options          Advanced options such as a map of auth information for custom auth
+     * @param onSuccess        Success callback
+     * @param onError          Error callback
      */
     void confirmResetPassword(
             @NonNull String username,
@@ -353,11 +393,12 @@ public interface AuthCategoryBehavior {
 
     /**
      * Complete password recovery process by inputting user's desired new password and confirmation code.
-     * @param username A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
-     * @param newPassword The user's desired new password
+     *
+     * @param username         A login identifier e.g. `superdog22`; or an email/phone number, depending on configuration
+     * @param newPassword      The user's desired new password
      * @param confirmationCode The confirmation code the user received after starting the forgotPassword process
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onSuccess        Success callback
+     * @param onError          Error callback
      */
     void confirmResetPassword(
             @NonNull String username,
@@ -368,10 +409,11 @@ public interface AuthCategoryBehavior {
 
     /**
      * Update the password of an existing user - must be signed in to perform this action.
+     *
      * @param oldPassword The user's existing password
      * @param newPassword The new password desired on the user account
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onSuccess   Success callback
+     * @param onError     Error callback
      */
     void updatePassword(
             @NonNull String oldPassword,
@@ -382,8 +424,9 @@ public interface AuthCategoryBehavior {
 
     /**
      * Fetch user attributes.
+     *
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void fetchUserAttributes(
             @NonNull Consumer<List<AuthUserAttribute>> onSuccess,
@@ -392,10 +435,11 @@ public interface AuthCategoryBehavior {
 
     /**
      * Update a single user attribute.
+     *
      * @param attribute Attribute to be updated
-     * @param options Advanced options such as a map of auth information for custom auth
+     * @param options   Advanced options such as a map of auth information for custom auth
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void updateUserAttribute(
             @NonNull AuthUserAttribute attribute,
@@ -406,9 +450,10 @@ public interface AuthCategoryBehavior {
 
     /**
      * Update a single user attribute.
+     *
      * @param attribute Attribute to be updated
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void updateUserAttribute(
             @NonNull AuthUserAttribute attribute,
@@ -417,10 +462,11 @@ public interface AuthCategoryBehavior {
 
     /**
      * Update multiple user attributes.
+     *
      * @param attributes Attributes to be updated
-     * @param options Advanced options such as a map of auth information for custom auth
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param options    Advanced options such as a map of auth information for custom auth
+     * @param onSuccess  Success callback
+     * @param onError    Error callback
      */
     void updateUserAttributes(
             @NonNull List<AuthUserAttribute> attributes,
@@ -431,9 +477,10 @@ public interface AuthCategoryBehavior {
 
     /**
      * Update multiple user attributes.
+     *
      * @param attributes Attributes to be updated
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onSuccess  Success callback
+     * @param onError    Error callback
      */
     void updateUserAttributes(
             @NonNull List<AuthUserAttribute> attributes,
@@ -444,10 +491,11 @@ public interface AuthCategoryBehavior {
     /**
      * If the user's confirmation code expires or they just missed it, this method
      * can be used to send them a new one.
+     *
      * @param attributeKey Key of attribute that user wants to operate on
-     * @param options Advanced options such as a map of auth information for custom auth
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param options      Advanced options such as a map of auth information for custom auth
+     * @param onSuccess    Success callback
+     * @param onError      Error callback
      */
     void resendUserAttributeConfirmationCode(
             @NonNull AuthUserAttributeKey attributeKey,
@@ -459,9 +507,10 @@ public interface AuthCategoryBehavior {
     /**
      * If the user's confirmation code expires or they just missed it, this method
      * can be used to send them a new one.
+     *
      * @param attributeKey Key of attribute that user wants to operate on
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onSuccess    Success callback
+     * @param onError      Error callback
      */
     void resendUserAttributeConfirmationCode(
             @NonNull AuthUserAttributeKey attributeKey,
@@ -471,10 +520,11 @@ public interface AuthCategoryBehavior {
 
     /**
      * Use attribute key and confirmation code to confirm user attribute.
-     * @param attributeKey Key of attribute that user wants to operate on
+     *
+     * @param attributeKey     Key of attribute that user wants to operate on
      * @param confirmationCode The confirmation code the user received after starting the user attribute operation
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onSuccess        Success callback
+     * @param onError          Error callback
      */
     void confirmUserAttribute(
             @NonNull AuthUserAttributeKey attributeKey,
@@ -485,8 +535,9 @@ public interface AuthCategoryBehavior {
 
     /**
      * Gets the currently logged in User.
+     *
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void getCurrentUser(
             @NonNull Consumer<AuthUser> onSuccess,
@@ -495,24 +546,31 @@ public interface AuthCategoryBehavior {
 
     /**
      * Sign out of the current device.
+     *
      * @param onComplete Complete callback
      */
-    void signOut(@NonNull Consumer<AuthSignOutResult> onComplete);
+    void signOut(@NonNull String username, @NonNull String userId, @NonNull Consumer<AuthSignOutResult> onComplete);
 
     /**
      * Sign out with advanced options.
-     * @param options Advanced options for sign out (e.g. whether to sign out of all devices globally)
+     *
+     * @param username
+     * @param userId
+     * @param options    Advanced options for sign out (e.g. whether to sign out of all devices globally)
      * @param onComplete Complete callback
      */
     void signOut(
+            @NonNull String username,
+            @NonNull String userId,
             @NonNull AuthSignOutOptions options,
             @NonNull Consumer<AuthSignOutResult> onComplete
     );
 
     /**
      * Delete the account of the currently signed in user.
+     *
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void deleteUser(
             @NonNull Action onSuccess,
@@ -520,59 +578,64 @@ public interface AuthCategoryBehavior {
 
     /**
      * Setup TOTP for the currently signed in user.
+     *
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void setUpTOTP(
-        @NonNull Consumer<TOTPSetupDetails> onSuccess,
-        @NonNull Consumer<AuthException> onError);
+            @NonNull Consumer<TOTPSetupDetails> onSuccess,
+            @NonNull Consumer<AuthException> onError);
 
     /**
      * Verify TOTP setup for the currently signed in user.
-     * @param code TOTP code to verify TOTP setup
+     *
+     * @param code      TOTP code to verify TOTP setup
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void verifyTOTPSetup(
-        @NonNull String code,
-        @NonNull Action onSuccess,
-        @NonNull Consumer<AuthException> onError
+            @NonNull String code,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError
     );
 
     /**
      * Verify TOTP setup for the currently signed in user.
-     * @param code TOTP code to verify TOTP setup
-     * @param options additional options to verify totp setup
+     *
+     * @param code      TOTP code to verify TOTP setup
+     * @param options   additional options to verify totp setup
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void verifyTOTPSetup(
-        @NonNull String code,
-        @NonNull AuthVerifyTOTPSetupOptions options,
-        @NonNull Action onSuccess,
-        @NonNull Consumer<AuthException> onError
+            @NonNull String code,
+            @NonNull AuthVerifyTOTPSetupOptions options,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError
     );
 
     /**
      * Create and register a passkey on this device, enabling passwordless sign in using passkeys.
      * The user must be signed in to call this API.
+     *
      * @param callingActivity The current Activity instance, used for launching the CredentialManager UI
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onSuccess       Success callback
+     * @param onError         Error callback
      */
     void associateWebAuthnCredential(
-        @NonNull Activity callingActivity,
-        @NonNull Action onSuccess,
-        @NonNull Consumer<AuthException> onError
+            @NonNull Activity callingActivity,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError
     );
 
     /**
      * Create and register a passkey on this device, enabling passwordless sign in using passkeys.
      * The user must be signed in to call this API.
+     *
      * @param callingActivity The current Activity instance, used for launching the CredentialManager UI
-     * @param options Advanced options for associating credentials
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param options         Advanced options for associating credentials
+     * @param onSuccess       Success callback
+     * @param onError         Error callback
      */
     void associateWebAuthnCredential(
             @NonNull Activity callingActivity,
@@ -584,20 +647,22 @@ public interface AuthCategoryBehavior {
     /**
      * Retrieve a list of WebAuthn credentials that are associated with the user's account.
      * The user must be signed in to call this API.
+     *
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void listWebAuthnCredentials(
-        @NonNull Consumer<AuthListWebAuthnCredentialsResult> onSuccess,
-        @NonNull Consumer<AuthException> onError
+            @NonNull Consumer<AuthListWebAuthnCredentialsResult> onSuccess,
+            @NonNull Consumer<AuthException> onError
     );
 
     /**
      * Retrieve a list of WebAuthn credentials that are associated with the user's account.
      * The user must be signed in to call this API.
-     * @param options Advanced options for listing credentials
+     *
+     * @param options   Advanced options for listing credentials
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void listWebAuthnCredentials(
             @NonNull AuthListWebAuthnCredentialsOptions options,
@@ -607,22 +672,24 @@ public interface AuthCategoryBehavior {
 
     /**
      * Delete the credential matching the given identifier.
+     *
      * @param credentialId The identifier for the credential to delete
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onSuccess    Success callback
+     * @param onError      Error callback
      */
     void deleteWebAuthnCredential(
-        @NonNull String credentialId,
-        @NonNull Action onSuccess,
-        @NonNull Consumer<AuthException> onError
+            @NonNull String credentialId,
+            @NonNull Action onSuccess,
+            @NonNull Consumer<AuthException> onError
     );
 
     /**
      * Delete the credential matching the given identifier.
+     *
      * @param credentialId The identifier for the credential to delete
-     * @param options Advanced options for deleting credentials
-     * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param options      Advanced options for deleting credentials
+     * @param onSuccess    Success callback
+     * @param onError      Error callback
      */
     void deleteWebAuthnCredential(
             @NonNull String credentialId,
@@ -633,8 +700,9 @@ public interface AuthCategoryBehavior {
 
     /**
      * Automatically sign in the user.
+     *
      * @param onSuccess Success callback
-     * @param onError Error callback
+     * @param onError   Error callback
      */
     void autoSignIn(
             @NonNull Consumer<AuthSignInResult> onSuccess,

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -553,13 +553,22 @@ public interface AuthCategoryBehavior {
     /**
      * Sign out with advanced options.
      *
-     * @param userId
+     * @param userId     The user ID of the user to sign out
      * @param options    Advanced options for sign out (e.g. whether to sign out of all devices globally)
      * @param onComplete Complete callback
      */
     void signOut(
             @NonNull String userId,
             @NonNull AuthSignOutOptions options,
+            @NonNull Consumer<AuthSignOutResult> onComplete
+    );
+
+    /**
+     * Sign out all users from the current device.
+     *
+     * @param onComplete Complete callback
+     */
+    void signOut(
             @NonNull Consumer<AuthSignOutResult> onComplete
     );
 

--- a/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
+++ b/core/src/main/java/com/amplifyframework/auth/AuthCategoryBehavior.java
@@ -299,6 +299,23 @@ public interface AuthCategoryBehavior {
      * @param onError   Error callback
      */
     void fetchAuthSession(
+            @NonNull String userId,
+            @NonNull AuthFetchSessionOptions options,
+            @NonNull Consumer<AuthSession> onSuccess,
+            @NonNull Consumer<AuthException> onError);
+
+    /**
+     * Retrieve the user's current session information - by default just whether they are signed out or in.
+     * Depending on how a plugin implements this, the resulting AuthSession can also be cast to a type specific
+     * to that plugin which contains the various security tokens and other identifying information if you want to
+     * manually use them outside the plugin. Within Amplify this should not be needed as the other categories will
+     * automatically work as long as you are signed in.
+     *
+     * @param options   Advanced options for force refresh session.
+     * @param onSuccess Success callback
+     * @param onError   Error callback
+     */
+    void fetchAuthSession(
             @NonNull AuthFetchSessionOptions options,
             @NonNull Consumer<AuthSession> onSuccess,
             @NonNull Consumer<AuthException> onError);

--- a/core/src/main/java/com/amplifyframework/auth/result/AuthSignInResult.java
+++ b/core/src/main/java/com/amplifyframework/auth/result/AuthSignInResult.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.auth.result;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
 import com.amplifyframework.auth.result.step.AuthNextSignInStep;
@@ -28,23 +29,50 @@ import java.util.Objects;
 public final class AuthSignInResult {
     private final boolean isSignedIn;
     private final AuthNextSignInStep nextStep;
+    private final String userId;
+
+    /**
+     * The email of the signed in user.
+     */
+    private final String username;
 
     /**
      * Wraps the result of a sign up operation.
+     *
      * @param isSignedIn True if the user is successfully authenticated, False otherwise. Check
-     *                         {@link #getNextStep()} to see if there are any required or optional steps to still
-     *                         be taken in the sign in flow.
-     * @param nextStep Details about the next step in the sign in process (or whether the flow is now done).
+     *                   {@link #getNextStep()} to see if there are any required or optional steps to still
+     *                   be taken in the sign in flow.
+     * @param nextStep   Details about the next step in the sign in process (or whether the flow is now done).
      */
     public AuthSignInResult(boolean isSignedIn, @NonNull AuthNextSignInStep nextStep) {
         this.isSignedIn = isSignedIn;
         this.nextStep = Objects.requireNonNull(nextStep);
+        this.userId = null;
+        this.username = null;
+    }
+
+    /**
+     * Wraps the result of a sign up operation.
+     *
+     * @param isSignedIn True if the user is successfully authenticated, False otherwise. Check
+     *                   {@link #getNextStep()} to see if there are any required or optional steps to still
+     *                   be taken in the sign in flow.
+     * @param username   The username of the signed in user if the user is successfully authenticated or null otherwise.
+     * @param userId     The user ID of the signed in user if the user is successfully authenticated or null otherwise.
+     * @param nextStep   Details about the next step in the sign in process (or whether the flow is now done).
+     */
+    public AuthSignInResult(boolean isSignedIn, String username, String userId, @NonNull AuthNextSignInStep nextStep) {
+        this.isSignedIn = isSignedIn;
+        this.nextStep = Objects.requireNonNull(nextStep);
+        this.username = username;
+        this.userId = userId;
     }
 
     /**
      * True if the user is successfully authenticated, False otherwise. Check
      * {@link #getNextStep()} to see if there are any required or optional steps to still
      * be taken in the sign in flow.
+     *
      * @return True if the user is successfully authenticated, False otherwise
      */
     public boolean isSignedIn() {
@@ -53,6 +81,7 @@ public final class AuthSignInResult {
 
     /**
      * Returns details about the next step in the sign in process (or whether the flow is now done).
+     *
      * @return details about the next step in the sign in process (or whether the flow is now done)
      */
     @NonNull
@@ -61,19 +90,42 @@ public final class AuthSignInResult {
     }
 
     /**
+     * Returns the user ID of the signed in user if the user is successfully authenticated or null otherwise.
+     *
+     * @return the user ID of the signed in user if the user is successfully authenticated or null otherwise
+     */
+    @Nullable
+    public String getUserId() {
+        return userId;
+    }
+
+    /**
+     * Returns the username of the signed in user if the user is successfully authenticated or null otherwise.
+     *
+     * @return the username of the signed in user if the user is successfully authenticated or null otherwise
+     */
+    @Nullable
+    public String getUsername() {
+        return username;
+    }
+
+    /**
      * When overriding, be sure to include isSignedIn and nextStep in the hash.
+     *
      * @return Hash code of this object
      */
     @Override
     public int hashCode() {
         return ObjectsCompat.hash(
                 isSignedIn(),
-                getNextStep()
+                getNextStep(),
+                getUserId()
         );
     }
 
     /**
      * When overriding, be sure to include isSignedIn and nextStep in the comparison.
+     *
      * @return True if the two objects are equal, false otherwise
      */
     @Override
@@ -85,19 +137,25 @@ public final class AuthSignInResult {
         } else {
             AuthSignInResult authSignUpResult = (AuthSignInResult) obj;
             return ObjectsCompat.equals(isSignedIn(), authSignUpResult.isSignedIn()) &&
-                    ObjectsCompat.equals(getNextStep(), authSignUpResult.getNextStep());
+                    ObjectsCompat.equals(getNextStep(), authSignUpResult.getNextStep())
+                    && ObjectsCompat.equals(getUserId(), authSignUpResult.getUserId())
+                    && ObjectsCompat.equals(getUsername(), authSignUpResult.getUsername());
         }
     }
 
     /**
      * When overriding, be sure to include isSignedIn and nextStep in the output string.
+     *
      * @return A string representation of the object
      */
+    @NonNull
     @Override
     public String toString() {
         return "AuthSignInResult{" +
                 "isSignedIn=" + isSignedIn() +
                 ", nextStep=" + getNextStep() +
+                ", username=" + getUsername() +
+                ", userId=" + getUserId() +
                 '}';
     }
 }

--- a/core/src/main/java/com/amplifyframework/core/plugin/Plugin.java
+++ b/core/src/main/java/com/amplifyframework/core/plugin/Plugin.java
@@ -16,6 +16,7 @@
 package com.amplifyframework.core.plugin;
 
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
@@ -34,14 +35,14 @@ import org.json.JSONObject;
  * added into the Amplify system before configuration, via calls to
  * {@link Amplify#addPlugin(Plugin)}. You can remove a plugin from the system
  * with {@link Amplify#removePlugin(Plugin)}.
- *
+ * <p>
  * The lifecycle of a plugin is:
  * 1. {@link #configure(JSONObject, Context)} is called, loading configuration data
- *    in a synchronous way. Do not do "heavy lifting" here, or you may cause ANRs.
+ * in a synchronous way. Do not do "heavy lifting" here, or you may cause ANRs.
  * 2. {@link #initialize(Context)} is called, providing an opportunity to initialize
- *    your plugin using the configuration that was loaded in the previous step.
- *    While this method is called synchronously from the Plugin's standpoint, it is
- *    executed async, in the background, by the Amplify framework.
+ * your plugin using the configuration that was loaded in the previous step.
+ * While this method is called synchronously from the Plugin's standpoint, it is
+ * executed async, in the background, by the Amplify framework.
  *
  * @param <E> The type of escape hatch provided by this plugin
  */
@@ -50,6 +51,7 @@ public interface Plugin<E> extends CategoryTypeable {
 
     /**
      * Gets a key which uniquely identifies the plugin instance.
+     *
      * @return the identifier that identifies the plugin implementation
      */
     @NonNull
@@ -59,11 +61,27 @@ public interface Plugin<E> extends CategoryTypeable {
      * Configure the plugin with customized configuration object. A
      * plugin may or may not require plugin configuration, so see
      * the documentation for details.
-     *
+     * <p>
      * This hook provides a good opportunity to instantiate resources.
      * Any long-lived initialization should take place in {@link #initialize(Context)}, instead.
+     *
      * @param pluginConfiguration plugin-specific configuration data
-     * @param context An Android Context
+     * @param context             An Android Context
+     * @throws AmplifyException an error is encountered during configuration.
+     */
+    default void configure(JSONObject pluginConfiguration, String userId, @NonNull Context context) throws AmplifyException {
+    }
+
+    /**
+     * Configure the plugin with customized configuration object. A
+     * plugin may or may not require plugin configuration, so see
+     * the documentation for details.
+     * <p>
+     * This hook provides a good opportunity to instantiate resources.
+     * Any long-lived initialization should take place in {@link #initialize(Context)}, instead.
+     *
+     * @param pluginConfiguration plugin-specific configuration data
+     * @param context             An Android Context
      * @throws AmplifyException an error is encountered during configuration.
      */
     void configure(JSONObject pluginConfiguration, @NonNull Context context) throws AmplifyException;
@@ -72,27 +90,29 @@ public interface Plugin<E> extends CategoryTypeable {
      * Configure the plugin with parsed AmplifyOutputs object. A
      * plugin may or may not require plugin configuration, so see
      * the documentation for details.
-     *
+     * <p>
      * This hook provides a good opportunity to instantiate resources.
      * Any long-lived initialization should take place in {@link #initialize(Context)}, instead.
+     *
      * @param configuration The AmplifyOutputs object
-     * @param context An Android Context
+     * @param context       An Android Context
      * @throws AmplifyException an error is encountered during configuration.
      */
     @InternalAmplifyApi
     default void configure(
-        @NonNull AmplifyOutputsData configuration,
-        @NonNull Context context
+            @NonNull AmplifyOutputsData configuration,
+            @NonNull Context context
     ) throws AmplifyException {
         throw new AmplifyException(
-            "This plugin version does not support the Gen2 configuration format",
-            "Use a newer version of this plugin that has support for the Amplify Gen2 configuration format"
+                "This plugin version does not support the Gen2 configuration format",
+                "Use a newer version of this plugin that has support for the Amplify Gen2 configuration format"
         );
     }
 
     /**
      * Initializes the plugin.
      * Perform any "heavy lifting" here.
+     *
      * @param context An Android Context
      * @throws AmplifyException On initialization failure
      */
@@ -101,6 +121,7 @@ public interface Plugin<E> extends CategoryTypeable {
 
     /**
      * Returns escape hatch for plugin to enable lower-level client use-cases.
+     *
      * @return the client used by category plugin; null, if there is no escape hatch
      */
     @Nullable
@@ -108,6 +129,7 @@ public interface Plugin<E> extends CategoryTypeable {
 
     /**
      * Returns the plugin version.
+     *
      * @return the plugin version
      */
     @NonNull

--- a/core/src/main/java/com/amplifyframework/core/store/EncryptedKeyValueRepository.kt
+++ b/core/src/main/java/com/amplifyframework/core/store/EncryptedKeyValueRepository.kt
@@ -51,6 +51,15 @@ class EncryptedKeyValueRepository @VisibleForTesting constructor(
     override fun get(dataKey: String): String? = sharedPreferences.getString(dataKey, null)
     override fun remove(dataKey: String) = edit { remove(dataKey) }
     override fun removeAll() = edit { clear() }
+    override fun removeAll(keyRegex: String) {
+        val keysToRemove = sharedPreferences.all.keys.filter { it.matches(Regex(keyRegex)) }
+        if (keysToRemove.isEmpty()) {
+            return
+        }
+        edit {
+            keysToRemove.forEach { remove(it) }
+        }
+    }
 
     private inline fun edit(crossinline block: SharedPreferences.Editor.() -> Unit) = with(sharedPreferences.edit()) {
         block()

--- a/core/src/main/java/com/amplifyframework/core/store/KeyValueRepository.kt
+++ b/core/src/main/java/com/amplifyframework/core/store/KeyValueRepository.kt
@@ -20,4 +20,5 @@ interface KeyValueRepository {
     fun get(dataKey: String): String?
     fun remove(dataKey: String)
     fun removeAll() = Unit
+    fun removeAll(keyRegex: String) = Unit
 }

--- a/core/src/test/java/com/amplifyframework/auth/AuthPluginTest.kt
+++ b/core/src/test/java/com/amplifyframework/auth/AuthPluginTest.kt
@@ -145,6 +145,7 @@ class AuthPluginTest {
         ) {}
         override fun handleWebUISignInResponse(intent: Intent?) {}
         override fun fetchAuthSession(onSuccess: Consumer<AuthSession>, onError: Consumer<AuthException>) {}
+        override fun fetchAuthSession(username: String, userId: String, onSuccess: Consumer<AuthSession>, onError: Consumer<AuthException>) {}
         override fun fetchAuthSession(
             options: AuthFetchSessionOptions,
             onSuccess: Consumer<AuthSession>,
@@ -230,8 +231,13 @@ class AuthPluginTest {
             onError: Consumer<AuthException>
         ) {}
         override fun getCurrentUser(onSuccess: Consumer<AuthUser>, onError: Consumer<AuthException>) {}
-        override fun signOut(onComplete: Consumer<AuthSignOutResult>) {}
-        override fun signOut(options: AuthSignOutOptions, onComplete: Consumer<AuthSignOutResult>) {}
+        override fun signOut(username: String, userId: String, onComplete: Consumer<AuthSignOutResult>) {}
+        override fun signOut(
+            username: String,
+            userId: String,
+            options: AuthSignOutOptions,
+            onComplete: Consumer<AuthSignOutResult>
+        ) {}
         override fun deleteUser(onSuccess: Action, onError: Consumer<AuthException>) {}
         override fun listWebAuthnCredentials(
             onSuccess: Consumer<AuthListWebAuthnCredentialsResult>,

--- a/core/src/test/java/com/amplifyframework/auth/AuthPluginTest.kt
+++ b/core/src/test/java/com/amplifyframework/auth/AuthPluginTest.kt
@@ -145,7 +145,11 @@ class AuthPluginTest {
         ) {}
         override fun handleWebUISignInResponse(intent: Intent?) {}
         override fun fetchAuthSession(onSuccess: Consumer<AuthSession>, onError: Consumer<AuthException>) {}
-        override fun fetchAuthSession(username: String, userId: String, onSuccess: Consumer<AuthSession>, onError: Consumer<AuthException>) {}
+        override fun fetchAuthSession(
+            userId: String,
+            onSuccess: Consumer<AuthSession>,
+            onError: Consumer<AuthException>
+        ) {}
         override fun fetchAuthSession(
             options: AuthFetchSessionOptions,
             onSuccess: Consumer<AuthSession>,
@@ -231,9 +235,11 @@ class AuthPluginTest {
             onError: Consumer<AuthException>
         ) {}
         override fun getCurrentUser(onSuccess: Consumer<AuthUser>, onError: Consumer<AuthException>) {}
-        override fun signOut(username: String, userId: String, onComplete: Consumer<AuthSignOutResult>) {}
         override fun signOut(
-            username: String,
+            userId: String,
+            onComplete: Consumer<AuthSignOutResult>
+        ) {}
+        override fun signOut(
             userId: String,
             options: AuthSignOutOptions,
             onComplete: Consumer<AuthSignOutResult>

--- a/maplibre-adapter/build.gradle.kts
+++ b/maplibre-adapter/build.gradle.kts
@@ -26,10 +26,16 @@ group = properties["POM_GROUP"].toString()
 android {
     namespace = "com.amplifyframework.geo.maplibre"
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
     lint {
         disable += "GradleDependency"
+    }
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 

--- a/rxbindings/build.gradle.kts
+++ b/rxbindings/build.gradle.kts
@@ -25,6 +25,12 @@ group = properties["POM_GROUP"].toString()
 
 android {
     namespace = "com.amplifyframework.rx"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
@@ -44,5 +50,5 @@ dependencies {
 }
 
 android.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -312,12 +312,12 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
 
     @Override
     public Single<AuthSignOutResult> signOut() {
-        return toSingle((onComplete, onError) -> delegate.signOut(onComplete));
+        return toSingle((onComplete, onError) -> delegate.signOut("","",onComplete));
     }
 
     @Override
     public Single<AuthSignOutResult> signOut(@NonNull AuthSignOutOptions options) {
-        return toSingle((onComplete, onError) -> delegate.signOut(options, onComplete));
+        return toSingle((onComplete, onError) -> delegate.signOut("", "", options, onComplete));
     }
 
     @Override

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -312,12 +312,12 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
 
     @Override
     public Single<AuthSignOutResult> signOut() {
-        return toSingle((onComplete, onError) -> delegate.signOut("","",onComplete));
+        return toSingle((onComplete, onError) -> delegate.signOut("",onComplete));
     }
 
     @Override
     public Single<AuthSignOutResult> signOut(@NonNull AuthSignOutOptions options) {
-        return toSingle((onComplete, onError) -> delegate.signOut("", "", options, onComplete));
+        return toSingle((onComplete, onError) -> delegate.signOut("", options, onComplete));
     }
 
     @Override

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthBinding.java
@@ -175,9 +175,9 @@ final class RxAuthBinding implements RxAuthCategoryBehavior {
     }
 
     @Override
-    public Single<AuthSession> fetchAuthSession(@NonNull AuthFetchSessionOptions options) {
+    public Single<AuthSession> fetchAuthSession(@NonNull String userId, @NonNull AuthFetchSessionOptions options) {
         return toSingle((onResult, onError) ->
-            delegate.fetchAuthSession(options, onResult, onError));
+            delegate.fetchAuthSession(userId, options, onResult, onError));
     }
 
     @Override

--- a/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
+++ b/rxbindings/src/main/java/com/amplifyframework/rx/RxAuthCategoryBehavior.java
@@ -17,6 +17,7 @@ package com.amplifyframework.rx;
 
 import android.app.Activity;
 import android.content.Intent;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -259,7 +260,7 @@ public interface RxAuthCategoryBehavior {
      * @return An Rx {@link Single} which emits {@link AuthSession} on success,
      *         {@link AuthException} on failure
      */
-    Single<AuthSession> fetchAuthSession(@NonNull AuthFetchSessionOptions options);
+    Single<AuthSession> fetchAuthSession(@NonNull String userId, @NonNull AuthFetchSessionOptions options);
 
     /**
      * Remember the user device that is currently being used.

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
@@ -1084,7 +1084,7 @@ public final class RxAuthBindingTest {
             Consumer<AuthSignOutResult> onComplete = invocation.getArgument(positionOfCompletionConsumer);
             onComplete.accept(new AuthSignOutResult());
             return null;
-        }).when(delegate).signOut(anyConsumer());
+        }).when(delegate).signOut("","",anyConsumer());
 
         // Act: call the binding
         TestObserver<AuthSignOutResult> observer = auth.signOut().test();

--- a/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
+++ b/rxbindings/src/test/java/com/amplifyframework/rx/RxAuthBindingTest.java
@@ -1084,7 +1084,7 @@ public final class RxAuthBindingTest {
             Consumer<AuthSignOutResult> onComplete = invocation.getArgument(positionOfCompletionConsumer);
             onComplete.accept(new AuthSignOutResult());
             return null;
-        }).when(delegate).signOut("","",anyConsumer());
+        }).when(delegate).signOut("",anyConsumer());
 
         // Act: call the binding
         TestObserver<AuthSignOutResult> observer = auth.signOut().test();

--- a/testmodels/build.gradle.kts
+++ b/testmodels/build.gradle.kts
@@ -20,6 +20,12 @@ plugins {
 
 android {
     namespace = "com.amplifyframework.testmodels"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {

--- a/testutils/build.gradle.kts
+++ b/testutils/build.gradle.kts
@@ -23,6 +23,12 @@ apply(from = rootProject.file("configuration/checkstyle.gradle"))
 
 android {
     namespace = "com.amplifyframework.testutils"
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -584,7 +584,7 @@ public final class SynchronousAuth {
      */
     public void signOut() throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
-                asyncDelegate.signOut(onResult::accept)
+                asyncDelegate.signOut("","",onResult::accept)
         );
     }
 
@@ -595,7 +595,7 @@ public final class SynchronousAuth {
      */
     public void signOut(AuthSignOutOptions options) throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
-                asyncDelegate.signOut(options, onResult::accept)
+                asyncDelegate.signOut("","" , options, onResult::accept)
         );
     }
 

--- a/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
+++ b/testutils/src/main/java/com/amplifyframework/testutils/sync/SynchronousAuth.java
@@ -584,7 +584,7 @@ public final class SynchronousAuth {
      */
     public void signOut() throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
-                asyncDelegate.signOut("","",onResult::accept)
+                asyncDelegate.signOut("",onResult::accept)
         );
     }
 
@@ -595,7 +595,7 @@ public final class SynchronousAuth {
      */
     public void signOut(AuthSignOutOptions options) throws AuthException {
         Await.<Object, AuthException>result(AUTH_OPERATION_TIMEOUT_MS, (onResult, onError) ->
-                asyncDelegate.signOut("","" , options, onResult::accept)
+                asyncDelegate.signOut("" , options, onResult::accept)
         );
     }
 


### PR DESCRIPTION
- fallback to old creds key to retrieve the creds after migration
- relay on user id instead of user name for state management