### PR TITLE
Fix NPE in CustomTabsManagerActivity after process death

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/activities/CustomTabsManagerActivity.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/activities/CustomTabsManagerActivity.kt
@@ -46,6 +46,14 @@ internal class CustomTabsManagerActivity : Activity() {
          * stack underneath the Chrome tab where they are going through the HostedUI flow.
          */
         if (!customTabsLaunched) {
+            if (customTabsIntent == null) {
+                // Custom tabs intent was lost (e.g. process death during OAuth flow).
+                // Cannot re-launch the browser, so finish gracefully. The auth redirect
+                // is handled separately by HostedUIRedirectActivity.
+                Log.d(TAG, "Custom tabs intent lost after process death, finishing.")
+                finish()
+                return
+            }
             startActivity(customTabsIntent)
             customTabsLaunched = true
             return


### PR DESCRIPTION
## Summary
- Fixes `NullPointerException` in `CustomTabsManagerActivity.onResume()` when the app process is killed during an OAuth flow
- When `HostedUIRedirectActivity` recreates `CustomTabsManagerActivity` via `createResponseHandlingIntent()`, the `customTabsIntent` is null (response intents only carry `data`, not the custom tabs extras). The existing `extractState()` detects this and calls `finish()`, but the lifecycle continues to `onResume()` which calls `startActivity(null)` → NPE
- Adds a null check before `startActivity()` — when null, finishes gracefully since the auth redirect is handled by `HostedUIRedirectActivity`

## Crashlytics
- Issue: `4ff0ef112a53df30988f5efc7c8277cf`
- First seen: v1.6.52, last seen: v1.9.4
- Heavily affects low-end devices (Samsung Galaxy A15/A16 5G, Moto G) where OS kills the process during browser OAuth

## Test plan
- [ ] Trigger SSO login on a low-memory device, switch to other apps to force process death, then return via OAuth redirect
- [ ] Verify the app finishes gracefully instead of crashing
- [ ] Verify normal SSO flow (no process death) still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)