### PR TITLE
fix(auth): don't crash when plugin configuration exceeds the 10s timeout (upstream #3321)

### DIFF
--- a/aws-auth-cognito/api/aws-auth-cognito.api
+++ b/aws-auth-cognito/api/aws-auth-cognito.api
@@ -10,6 +10,7 @@ public final class com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin : com/
 	public static final field AWS_COGNITO_AUTH_LOG_NAMESPACE Ljava/lang/String;
 	public static final field Companion Lcom/amplifyframework/auth/cognito/AWSCognitoAuthPlugin$Companion;
 	public fun <init> ()V
+	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/auth/options/AuthAssociateWebAuthnCredentialsOptions;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun associateWebAuthnCredential (Landroid/app/Activity;Lcom/amplifyframework/core/Action;Lcom/amplifyframework/core/Consumer;)V
 	public fun autoSignIn (Lcom/amplifyframework/core/Consumer;Lcom/amplifyframework/core/Consumer;)V

--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.kt
@@ -68,6 +68,7 @@ import com.amplifyframework.core.Consumer
 import com.amplifyframework.core.configuration.AmplifyOutputsData
 import com.amplifyframework.statemachine.codegen.events.AuthEvent
 import com.amplifyframework.statemachine.codegen.states.AuthState
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -77,17 +78,21 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 
 /**
  * A Cognito implementation of the Auth Plugin.
  */
-class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
+class AWSCognitoAuthPlugin internal constructor(
+    private val configurationTimeout: Duration = 10.seconds
+) : AuthPlugin<AWSCognitoAuthService>() {
     companion object {
         const val AWS_COGNITO_AUTH_LOG_NAMESPACE = "amplify:aws-cognito-auth:%s"
         private const val AWS_COGNITO_AUTH_PLUGIN_KEY = "awsCognitoAuthPlugin"
     }
+
+    constructor() : this(configurationTimeout = 10.seconds)
 
     private val logger = authLogger()
 
@@ -127,9 +132,10 @@ class AWSCognitoAuthPlugin : AuthPlugin<AWSCognitoAuthService>() {
     }
 
     override fun initialize(context: Context) {
-        // Block until the state machine is in the configured state.
+        // Wait up to the configured timeout for the state machine to reach Configured, but do not throw on timeout.
+        // This matches legacy behavior where initialization proceeds regardless of whether configuration completes.
         runBlocking {
-            withTimeout(10.seconds) {
+            withTimeoutOrNull(configurationTimeout) {
                 suspendWhileConfiguring()
             }
         }

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPluginTest.kt
@@ -54,12 +54,15 @@ import com.amplifyframework.auth.result.AuthSignUpResult
 import com.amplifyframework.auth.result.AuthUpdateAttributeResult
 import com.amplifyframework.core.Action
 import com.amplifyframework.core.Consumer
+import com.amplifyframework.statemachine.codegen.states.AuthState
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeBlank
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.flow.MutableSharedFlow
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
@@ -898,5 +901,30 @@ class AWSCognitoAuthPluginTest {
         val useCase = authPlugin.useCaseFactory.webUISignInResponse()
         authPlugin.handleWebUISignInResponse(null)
         coVerify(timeout = CHANNEL_TIMEOUT) { useCase.execute(null) }
+    }
+
+    @Test
+    fun `initialize completes when state machine reaches Configured`() {
+        val plugin = AWSCognitoAuthPlugin(configurationTimeout = 100.milliseconds)
+        plugin.authStateMachine = mockk(relaxed = true)
+
+        val stateFlow = MutableSharedFlow<AuthState>(replay = 1)
+        stateFlow.tryEmit(AuthState.Configured(null, null, null))
+        every { plugin.authStateMachine.state } returns stateFlow
+
+        plugin.initialize(mockk())
+    }
+
+    @Test
+    fun `initialize does not throw when state machine does not reach Configured within timeout`() {
+        val plugin = AWSCognitoAuthPlugin(configurationTimeout = 100.milliseconds)
+        plugin.authStateMachine = mockk(relaxed = true)
+
+        val stateFlow = MutableSharedFlow<AuthState>(replay = 1)
+        stateFlow.tryEmit(AuthState.ConfiguringAuth())
+        every { plugin.authStateMachine.state } returns stateFlow
+
+        // Should complete without throwing despite the state never reaching Configured
+        plugin.initialize(mockk())
     }
 }


### PR DESCRIPTION
Cherry-pick of upstream aws-amplify/amplify-android PR #3321 (commit ca14fedc, released in v2.37.0) onto our 2.36.1-harri line.

## Problem
TL 1.10.7/1.10.8 FATAL crash (Crashlytics issue 1d2f7833d3c581014358035982eddba7): TimeoutCancellationException: Timed out waiting for 10000 ms.

Upstream 2.36.x introduced a throwing withTimeout(10.seconds) inside AWSCognitoAuthPlugin.initialize(). When auth configuration takes longer than 10s (observed: legacy credential-store migration hanging in an Android Keystore binder call), the TimeoutCancellationException is not an AmplifyException, so Category.initialize does not catch it and the app dies on the plugin-init worker thread. Known upstream regression: issue #3318, fixed by PR #3321.

## Fix
withTimeout -> withTimeoutOrNull(configurationTimeout): initialization waits up to the timeout but proceeds without throwing; subsequent auth calls queue until configuration completes. Includes upstream's internal constructor for a testable timeout and its unit test.

Note vs pre-2.36 behavior: 2.30.x initialize() had no blocking wait at all; this change can block boot up to 10s on slow-keystore devices before proceeding. Worth watching ANR rate on the release.

## Verification
- Clean cherry-pick (-x), no conflicts
- :aws-auth-cognito AWSCognitoAuthPluginTest green (includes the new timeout test)
- ktlintCheck clean; no public API change

Root-cause investigation by Rami Hussien. Part 1 of the 2.36.2-harri candidate; the HARRI-368859 hosted-UI sign-in fix stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)