### PR TITLE
fix(auth): allow hosted-UI sign-in to recover from a stale global SignedIn state (HARRI-368859)

### DIFF
--- a/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/WebUiSignInUseCase.kt
+++ b/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/usecases/WebUiSignInUseCase.kt
@@ -22,7 +22,6 @@ import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.auth.cognito.AuthStateMachine
 import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidOauthConfigurationException
 import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
-import com.amplifyframework.auth.cognito.exceptions.invalidstate.SignedInException
 import com.amplifyframework.auth.cognito.helpers.HostedUIHelper
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthWebUISignInOptions
 import com.amplifyframework.auth.cognito.toAuthException
@@ -101,14 +100,25 @@ internal class WebUiSignInUseCase(
 
     private suspend fun waitForStateThatAllowsSignIn() {
         stateMachine.state.mapNotNull { authState ->
-            when (authState.authNState) {
+            when (val authNState = authState.authNState) {
                 is AuthenticationState.NotConfigured -> throw InvalidUserPoolConfigurationException()
-                is AuthenticationState.SignedOut -> authState
-                is AuthenticationState.SignedIn -> throw SignedInException()
+                is AuthenticationState.SignedOut, is AuthenticationState.Configured -> authState
+                is AuthenticationState.SignedIn -> {
+                    // Multi-user fork: mirror SignInUseCase. Another user's (or a stale) global
+                    // SignedIn state must not reject a hosted-UI sign-in with SignedInException —
+                    // that permanently locked out SSO-only users whenever the global session
+                    // diverged from the app's account state (HARRI-368859). Reset only the GLOBAL
+                    // state to a signable state, keeping every user's persisted per-user session
+                    // in AuthStateRepo intact, then proceed once a signable state is observed.
+                    stateMachine.prepareForReSignIn()
+                    null
+                }
+                is AuthenticationState.SigningOut -> null
                 is AuthenticationState.SigningIn -> {
                     stateMachine.send(AuthenticationEvent(AuthenticationEvent.EventType.CancelSignIn()))
                     null
                 }
+                is AuthenticationState.Error -> throw authNState.exception.toAuthException("Sign in failed.")
                 else -> throw InvalidStateException()
             }
         }.first()

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/AuthValidationTest.kt
@@ -29,7 +29,6 @@ import com.amplifyframework.auth.cognito.usecases.SignInUseCase
 import com.amplifyframework.auth.cognito.usecases.SignOutUseCase
 import com.amplifyframework.auth.cognito.usecases.WebUiSignInResponseUseCase
 import com.amplifyframework.auth.cognito.usecases.WebUiSignInUseCase
-import com.amplifyframework.auth.exceptions.InvalidStateException
 import com.amplifyframework.auth.result.AuthSignInResult
 import com.amplifyframework.logging.Logger
 import com.amplifyframework.statemachine.codegen.data.AmplifyCredential
@@ -253,38 +252,43 @@ class AuthValidationTest {
 //region SRP and HostedUI
 
     // SRP/Hosted 1
-    // Expected: SRP sign in succeeded, Hosted UI sign in fails, user is still signed in
+    // Expected (multi-user): SRP sign in succeeded, Hosted UI sign in also succeeds — the gate
+    // resets only the global session for re-sign-in instead of rejecting with SignedInException,
+    // preserving per-user sessions (HARRI-368859: SSO-only users were locked out by the old gate).
     @Test
     fun `SRP sign in existing user with correct password, Hosted UI sign in`() {
         signIn(USERNAME_1, PASSWORD_1)
-        shouldThrow<InvalidStateException> { signInHostedUi() }
+        val result = signInHostedUi()
+        assertTrue(result.isSignedIn)
         assertSignedInAs(USERNAME_1)
     }
 
     // SRP/Hosted 2
-    // Expected: Hosted UI sign in succeeded, SRP sign in fails, user is still signed in
+    // Expected (multi-user): Hosted UI sign in succeeded, SRP sign in also succeeds — the native
+    // gate resets the global session for re-sign-in instead of rejecting while signed in.
     @Test
     fun `Hosted UI sign in, SRP sign in existing user with correct password`() {
         signInHostedUi()
-        shouldThrow<InvalidStateException> { signIn(USERNAME_1, PASSWORD_1) }
+        signIn(USERNAME_1, PASSWORD_1)
         assertSignedInAs(USERNAME_1)
     }
 
     // SRP/Hosted 3
-    // Expected: Hosted UI sign in succeeded, SRP sign in fails, user is still signed in
+    // Expected (multi-user): Hosted UI sign in succeeded, the second sign-in proceeds past the
+    // gate and fails with the real credential error instead of InvalidStateException.
     @Test
     fun `Hosted UI sign in, SRP sign in existing user with incorrect password`() {
         signInHostedUi()
-        shouldThrow<InvalidStateException> { signIn(USERNAME_1, INCORRECT_PASSWORD) }
-        assertSignedInAs(USERNAME_1)
+        shouldThrow<InvalidPasswordException> { signIn(USERNAME_1, INCORRECT_PASSWORD) }
     }
 
     // SRP/Hosted 4
-    // Expected: Hosted UI sign in succeeded, SRP sign in fails, user is still signed in
+    // Expected (multi-user): Hosted UI sign in succeeded, the second sign-in proceeds past the
+    // gate and fails with the real user-not-found error instead of InvalidStateException.
     @Test
     fun `Hosted UI sign in, SRP sign in non-existent user`() {
         signInHostedUi()
-        shouldThrow<InvalidStateException> { signIn(INVALID_USERNAME, PASSWORD_1) }
+        shouldThrow<UserNotFoundException> { signIn(INVALID_USERNAME, PASSWORD_1) }
     }
 
     // SRP/Hosted 5

--- a/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/WebUiSignInUseCaseTest.kt
+++ b/aws-auth-cognito/src/test/java/com/amplifyframework/auth/cognito/usecases/WebUiSignInUseCaseTest.kt
@@ -22,7 +22,6 @@ import com.amplifyframework.auth.cognito.AuthConfiguration
 import com.amplifyframework.auth.cognito.AuthStateMachine
 import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidOauthConfigurationException
 import com.amplifyframework.auth.cognito.exceptions.configuration.InvalidUserPoolConfigurationException
-import com.amplifyframework.auth.cognito.exceptions.invalidstate.SignedInException
 import com.amplifyframework.auth.cognito.mockSignedInData
 import com.amplifyframework.auth.cognito.testUtil.authState
 import com.amplifyframework.auth.exceptions.InvalidStateException
@@ -43,6 +42,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -101,15 +101,77 @@ class WebUiSignInUseCaseTest {
     }
 
     @Test
-    fun `throws SignedInException when already signed in`() = runTest {
+    fun `resets global state and proceeds when another user is already signed in`() = runTest {
+        // Multi-user: the gate observes a SignedIn state. Instead of throwing SignedInException it
+        // must reset the global state to a signable state (preserving per-user sessions) and
+        // proceed with the hosted-UI sign-in (HARRI-368859: SSO-only users were locked out).
         stateFlow.value = authState(
             authNState = AuthenticationState.SignedIn(mockSignedInData(), mockk()),
+            authZState = AuthorizationState.SessionEstablished(mockk())
+        )
+        coEvery { stateMachine.prepareForReSignIn() } answers {
+            stateFlow.value = authState(
+                authNState = AuthenticationState.SignedOut(SignedOutData()),
+                authZState = AuthorizationState.Configured()
+            )
+        }
+
+        val deferred = backgroundScope.async {
+            useCase.execute(provider = AuthProvider.google(), callingActivity = callingActivity)
+        }
+        runCurrent()
+
+        coVerify { stateMachine.prepareForReSignIn() }
+        verify {
+            stateMachine.send(
+                withArg<StateMachineEvent> {
+                    val event = it.shouldBeInstanceOf<AuthenticationEvent>()
+                    val type = event.eventType
+                        .shouldBeInstanceOf<AuthenticationEvent.EventType.SignInRequested>()
+                    type.signInData.shouldBeInstanceOf<SignInData.HostedUISignInData>()
+                }
+            )
+        }
+
+        stateFlow.value = authState(
+            authNState = AuthenticationState.SignedIn(mockSignedInData(), mockk()),
+            authZState = AuthorizationState.SessionEstablished(mockk())
+        )
+
+        val result = deferred.await()
+        result.isSignedIn shouldBe true
+    }
+
+    @Test
+    fun `proceeds with sign in from the Configured state`() = runTest {
+        // prepareForReSignIn resets the global state to Configured — the gate must treat it as
+        // signable exactly like SignInUseCase does, not reject it with InvalidStateException.
+        stateFlow.value = authState(
+            authNState = AuthenticationState.Configured(),
             authZState = AuthorizationState.Configured()
         )
 
-        shouldThrow<SignedInException> {
+        val deferred = backgroundScope.async {
             useCase.execute(callingActivity = callingActivity)
         }
+        runCurrent()
+
+        verify {
+            stateMachine.send(
+                withArg<StateMachineEvent> {
+                    val event = it.shouldBeInstanceOf<AuthenticationEvent>()
+                    event.eventType.shouldBeInstanceOf<AuthenticationEvent.EventType.SignInRequested>()
+                }
+            )
+        }
+
+        stateFlow.value = authState(
+            authNState = AuthenticationState.SignedIn(mockSignedInData(), mockk()),
+            authZState = AuthorizationState.SessionEstablished(mockk())
+        )
+
+        val result = deferred.await()
+        result.isSignedIn shouldBe true
     }
 
     @Test
@@ -297,11 +359,23 @@ class WebUiSignInUseCaseTest {
     @Test
     fun `throws InvalidStateException for unexpected states`() = runTest {
         stateFlow.value = authState(
-            authNState = AuthenticationState.Configured(),
+            authNState = AuthenticationState.FederatedToIdentityPool(),
             authZState = AuthorizationState.Configured()
         )
 
         shouldThrow<InvalidStateException> {
+            useCase.execute(callingActivity = callingActivity)
+        }
+    }
+
+    @Test
+    fun `throws AuthException when the authentication state is Error`() = runTest {
+        stateFlow.value = authState(
+            authNState = AuthenticationState.Error(RuntimeException("boom")),
+            authZState = AuthorizationState.Configured()
+        )
+
+        shouldThrow<UnknownException> {
             useCase.execute(callingActivity = callingActivity)
         }
     }


### PR DESCRIPTION
Re-opened replacement for #7, which GitHub auto-closed when #6's base branch was deleted on merge. Same two commits, now based on the updated multi-user line (#6 already merged).

See #7 for the full description, fork-compatibility audit, and AuthValidationTest triage. Summary:
- WebUiSignInUseCase.waitForStateThatAllowsSignIn now mirrors SignInUseCase: prepareForReSignIn() on SignedIn (instead of throwing SignedInException), accepts Configured, surfaces Error as AuthException. Fixes the permanent SSO lockout (HARRI-368859).
- AuthValidationTest SRP/Hosted 1-4 matrix rows updated to multi-user expectations (3 were already failing on baseline).
- Verified: full :aws-auth-cognito suite 572/572, apiCheck PASS, ktlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)